### PR TITLE
Have app store hit prod and then sandbox if 21007

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -102,7 +102,7 @@ type (
 	// We defined each field by the current IAP response, but some fields are not mentioned
 	// in the following Apple's document;
 	// https://developer.apple.com/library/ios/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html
-	// If you get other types or fileds from the IAP response, you should use the struct you defined.
+	// If you get other types or fields from the IAP response, you should use the struct you defined.
 	IAPResponse struct {
 		Status             int                  `json:"status"`
 		Environment        string               `json:"environment"`
@@ -111,5 +111,11 @@ type (
 		LatestReceipt      string               `json:"latest_receipt"`
 		PendingRenewalInfo []PendingRenewalInfo `json:"pending_renewal_info"`
 		IsRetryable        bool                 `json:"is-retryable"`
+	}
+
+	// The HttpStatusResponse struct contains the status code returned by the store
+	// Used as a workaround to detect when to hit the production appstore or sandbox appstore regardless of receipt type
+	HttpStatusResponse struct {
+		Status int `json:"status"`
 	}
 )

--- a/appstore/model.go
+++ b/appstore/model.go
@@ -115,7 +115,7 @@ type (
 
 	// The HttpStatusResponse struct contains the status code returned by the store
 	// Used as a workaround to detect when to hit the production appstore or sandbox appstore regardless of receipt type
-	HttpStatusResponse struct {
+	StatusResponse struct {
 		Status int `json:"status"`
 	}
 )

--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -115,7 +115,10 @@ func (c *Client) Verify(req IAPRequest, result interface{}) error {
 		return err
 	}
 	defer resp.Body.Close()
+	return c.parseResponse(resp, result, client, req)
+}
 
+func (c *Client) parseResponse(resp *http.Response, result interface{}, client http.Client, req IAPRequest) error {
 	// Read the body now so that we can unmarshal it twice
 	buf, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -134,7 +137,7 @@ func (c *Client) Verify(req IAPRequest, result interface{}) error {
 		return err
 	}
 	if r.Status == 21007 {
-		b = new(bytes.Buffer)
+		b := new(bytes.Buffer)
 		json.NewEncoder(b).Encode(req)
 		resp, err := client.Post(c.SandboxURL, "application/json; charset=utf-8", b)
 		if err != nil {

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -183,7 +183,7 @@ func TestVerifyBadURL(t *testing.T) {
 }
 
 func TestVerifyBadPayload(t *testing.T) {
-	s := httptest.NewServer(serverWithResponse(`{"status": 21002}`))
+	s := httptest.NewServer(serverWithResponse(http.StatusBadRequest, `{"status": 21002}`))
 	defer s.Close()
 
 	client := New()
@@ -206,7 +206,7 @@ func TestVerifyBadPayload(t *testing.T) {
 }
 
 func TestVerifyBadResponse(t *testing.T) {
-	s := httptest.NewServer(serverWithResponse(`qwerty!@#$%^`))
+	s := httptest.NewServer(serverWithResponse(http.StatusInternalServerError, `qwerty!@#$%^`))
 	defer s.Close()
 
 	client := New()
@@ -223,10 +223,10 @@ func TestVerifyBadResponse(t *testing.T) {
 }
 
 func TestVerifySandboxReceipt(t *testing.T) {
-	s := httptest.NewServer(serverWithResponse(`{"status": 21007}`))
+	s := httptest.NewServer(serverWithResponse(http.StatusOK, `{"status": 21007}`))
 	defer s.Close()
 
-	sandboxServ := httptest.NewServer(serverWithResponse(`{"status": 0}`))
+	sandboxServ := httptest.NewServer(serverWithResponse(http.StatusOK, `{"status": 0}`))
 	defer sandboxServ.Close()
 
 	client := New()
@@ -252,7 +252,7 @@ func TestVerifySandboxReceipt(t *testing.T) {
 }
 
 func TestVerifySandboxReceiptFailure(t *testing.T) {
-	s := httptest.NewServer(serverWithResponse(`{"status": 21007}`))
+	s := httptest.NewServer(serverWithResponse(http.StatusOK, `{"status": 21007}`))
 	defer s.Close()
 
 	client := New()
@@ -295,7 +295,7 @@ func (errReader) Read(p []byte) (n int, err error) {
 	return 0, errors.New("test error")
 }
 
-func serverWithResponse(response string) http.Handler {
+func serverWithResponse(statusCode int, response string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if "POST" == r.Method {
 			w.Header().Set("Content-Type", "application/json")
@@ -305,6 +305,6 @@ func serverWithResponse(response string) http.Handler {
 			w.Write([]byte(`unsupported request`))
 		}
 
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(statusCode)
 	})
 }

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -93,9 +93,9 @@ func TestHandleError(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	expected := Client{
-		ProductionURL: SandboxURL,
-		TimeOut:       time.Second * 5,
+		ProductionURL: ProductionURL,
 		SandboxURL:    SandboxURL,
+		TimeOut:       time.Second * 5,
 	}
 
 	actual := New()
@@ -127,6 +127,7 @@ func TestNewWithConfig(t *testing.T) {
 
 	expected := Client{
 		ProductionURL: ProductionURL,
+		SandboxURL:    SandboxURL,
 		TimeOut:       time.Second * 2,
 	}
 
@@ -141,6 +142,7 @@ func TestNewWithConfigTimeout(t *testing.T) {
 
 	expected := Client{
 		ProductionURL: ProductionURL,
+		SandboxURL:    SandboxURL,
 		TimeOut:       time.Second * 5,
 	}
 

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -2,12 +2,12 @@ package appstore
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"testing"
 	"time"
-	"net/http/httptest"
-	"net/http"
 )
 
 func TestHandleError(t *testing.T) {
@@ -93,9 +93,9 @@ func TestHandleError(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	expected := Client{
-		URL:     SandboxURL,
-		TimeOut: time.Second * 5,
-		SandboxURL:SandboxURL,
+		ProductionURL: SandboxURL,
+		TimeOut:       time.Second * 5,
+		SandboxURL:    SandboxURL,
 	}
 
 	actual := New()
@@ -106,9 +106,9 @@ func TestNew(t *testing.T) {
 
 func TestNewWithEnvironment(t *testing.T) {
 	expected := Client{
-		URL:     ProductionURL,
-		TimeOut: time.Second * 5,
-		SandboxURL:SandboxURL,
+		ProductionURL: ProductionURL,
+		TimeOut:       time.Second * 5,
+		SandboxURL:    SandboxURL,
 	}
 
 	os.Setenv("IAP_ENVIRONMENT", "production")
@@ -122,13 +122,12 @@ func TestNewWithEnvironment(t *testing.T) {
 
 func TestNewWithConfig(t *testing.T) {
 	config := Config{
-		IsProduction: true,
-		TimeOut:      time.Second * 2,
+		TimeOut: time.Second * 2,
 	}
 
 	expected := Client{
-		URL:     ProductionURL,
-		TimeOut: time.Second * 2,
+		ProductionURL: ProductionURL,
+		TimeOut:       time.Second * 2,
 	}
 
 	actual := NewWithConfig(config)
@@ -138,13 +137,11 @@ func TestNewWithConfig(t *testing.T) {
 }
 
 func TestNewWithConfigTimeout(t *testing.T) {
-	config := Config{
-		IsProduction: true,
-	}
+	config := Config{}
 
 	expected := Client{
-		URL:     ProductionURL,
-		TimeOut: time.Second * 5,
+		ProductionURL: ProductionURL,
+		TimeOut:       time.Second * 5,
 	}
 
 	actual := NewWithConfig(config)
@@ -169,7 +166,7 @@ func TestVerifyTimeout(t *testing.T) {
 
 func TestVerifyBadURL(t *testing.T) {
 	client := New()
-	client.URL = "127.0.0.1"
+	client.ProductionURL = "127.0.0.1"
 
 	req := IAPRequest{
 		ReceiptData: "dummy data",
@@ -186,7 +183,7 @@ func TestVerifyBadPayload(t *testing.T) {
 	defer s.Close()
 
 	client := New()
-	client.URL = s.URL
+	client.ProductionURL = s.URL
 	expected := &IAPResponse{
 		Status: 21002,
 	}
@@ -209,7 +206,7 @@ func TestVerifyBadResponse(t *testing.T) {
 	defer s.Close()
 
 	client := New()
-	client.URL = s.URL
+	client.ProductionURL = s.URL
 	req := IAPRequest{
 		ReceiptData: "dummy data",
 	}
@@ -229,7 +226,7 @@ func TestVerifySandboxReceipt(t *testing.T) {
 	defer sandboxServ.Close()
 
 	client := New()
-	client.URL = s.URL
+	client.ProductionURL = s.URL
 	client.TimeOut = time.Second * 100
 	client.SandboxURL = sandboxServ.URL
 
@@ -255,7 +252,7 @@ func TestVerifySandboxReceiptFailure(t *testing.T) {
 	defer s.Close()
 
 	client := New()
-	client.URL = s.URL
+	client.ProductionURL = s.URL
 	client.TimeOut = time.Second * 100
 	client.SandboxURL = "localhost"
 

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -257,6 +257,7 @@ func TestVerifySandboxReceiptFailure(t *testing.T) {
 	client := New()
 	client.URL = s.URL
 	client.TimeOut = time.Second * 100
+	client.SandboxURL = "localhost"
 
 	req := IAPRequest{
 		ReceiptData: "dummy data",

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+	"net/http/httptest"
+	"net/http"
 )
 
 func TestHandleError(t *testing.T) {
@@ -91,8 +93,9 @@ func TestHandleError(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	expected := Client{
-		URL:     "https://sandbox.itunes.apple.com/verifyReceipt",
+		URL:     SandboxURL,
 		TimeOut: time.Second * 5,
+		SandboxURL:SandboxURL,
 	}
 
 	actual := New()
@@ -103,8 +106,9 @@ func TestNew(t *testing.T) {
 
 func TestNewWithEnvironment(t *testing.T) {
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 5,
+		SandboxURL:SandboxURL,
 	}
 
 	os.Setenv("IAP_ENVIRONMENT", "production")
@@ -123,7 +127,7 @@ func TestNewWithConfig(t *testing.T) {
 	}
 
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 2,
 	}
 
@@ -139,7 +143,7 @@ func TestNewWithConfigTimeout(t *testing.T) {
 	}
 
 	expected := Client{
-		URL:     "https://buy.itunes.apple.com/verifyReceipt",
+		URL:     ProductionURL,
 		TimeOut: time.Second * 5,
 	}
 
@@ -149,9 +153,9 @@ func TestNewWithConfigTimeout(t *testing.T) {
 	}
 }
 
-func TestVerify(t *testing.T) {
+func TestVerifyTimeout(t *testing.T) {
 	client := New()
-	client.TimeOut = time.Millisecond * 100
+	client.TimeOut = time.Millisecond
 
 	req := IAPRequest{
 		ReceiptData: "dummy data",
@@ -161,13 +165,172 @@ func TestVerify(t *testing.T) {
 	if err == nil {
 		t.Errorf("error should be occurred because of timeout")
 	}
+}
 
-	client = New()
+func TestVerifyBadURL(t *testing.T) {
+	client := New()
+	client.URL = "127.0.0.1"
+
+	req := IAPRequest{
+		ReceiptData: "dummy data",
+	}
+	result := &IAPResponse{}
+	err := client.Verify(req, result)
+	if err == nil {
+		t.Errorf("error should be occurred because the server is not real")
+	}
+}
+
+func TestVerifyBadPayload(t *testing.T) {
+	s := httptest.NewServer(badPayload())
+	defer s.Close()
+
+	client := New()
+	client.URL = s.URL
 	expected := &IAPResponse{
 		Status: 21002,
 	}
-	client.Verify(req, result)
+	req := IAPRequest{
+		ReceiptData: "dummy data",
+	}
+	result := &IAPResponse{}
+
+	err := client.Verify(req, result)
+	if err != nil {
+		t.Errorf("got error %s", err)
+	}
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("got %v\nwant %v", result, expected)
 	}
+}
+
+func TestVerifyBadResponse(t *testing.T) {
+	s := httptest.NewServer(invalidResponse())
+	defer s.Close()
+
+	client := New()
+	client.URL = s.URL
+	req := IAPRequest{
+		ReceiptData: "dummy data",
+	}
+	result := &IAPResponse{}
+
+	err := client.Verify(req, result)
+	if err == nil {
+		t.Errorf("expected an error because Verify could not unmarshal server response")
+	}
+}
+
+func TestVerifySandboxReceipt(t *testing.T) {
+	s := httptest.NewServer(redirectToSandbox())
+	defer s.Close()
+
+	sandboxServ := httptest.NewServer(sandboxSuccess())
+	defer sandboxServ.Close()
+
+	client := New()
+	client.URL = s.URL
+	client.TimeOut = time.Second * 100
+	client.SandboxURL = sandboxServ.URL
+
+	expected := &IAPResponse{
+		Status: 0,
+	}
+	req := IAPRequest{
+		ReceiptData: "dummy data",
+	}
+	result := &IAPResponse{}
+
+	err := client.Verify(req, result)
+	if err != nil {
+		t.Errorf("got error %s", err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("got %v\nwant %v", result, expected)
+	}
+}
+
+func TestVerifySandboxReceiptFailure(t *testing.T) {
+	s := httptest.NewServer(redirectToSandbox())
+	defer s.Close()
+
+	sandboxServ := httptest.NewServer(sandboxTimeout())
+	defer sandboxServ.Close()
+
+	client := New()
+	client.URL = s.URL
+	client.TimeOut = time.Second * 100
+	client.SandboxURL = sandboxServ.URL
+
+	req := IAPRequest{
+		ReceiptData: "dummy data",
+	}
+	result := &IAPResponse{}
+
+	err := client.Verify(req, result)
+	if err == nil {
+		t.Errorf("expected error to be not nil since the sandbox is not responding")
+	}
+}
+
+func badPayload() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if "POST" == r.Method {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"status": 21002}`))
+			return
+		} else {
+			w.Write([]byte(`unsupported request`))
+		}
+
+		w.WriteHeader(http.StatusBadRequest)
+	})
+}
+
+func redirectToSandbox() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if "POST" == r.Method {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"status": 21007}`))
+			return
+		} else {
+			w.Write([]byte(`unsupported request`))
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func sandboxSuccess() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if "POST" == r.Method {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"status": 0}`))
+			return
+		} else {
+			w.Write([]byte(`unsupported request`))
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func sandboxTimeout() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Do nothing and just dont return anything either
+	})
+}
+
+func invalidResponse() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if "POST" == r.Method {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`qwerty!@#$%^`))
+			return
+		} else {
+			w.Write([]byte(`unsupported request`))
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
 }

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -254,13 +254,9 @@ func TestVerifySandboxReceiptFailure(t *testing.T) {
 	s := httptest.NewServer(redirectToSandbox())
 	defer s.Close()
 
-	sandboxServ := httptest.NewServer(sandboxTimeout())
-	defer sandboxServ.Close()
-
 	client := New()
 	client.URL = s.URL
 	client.TimeOut = time.Second * 100
-	client.SandboxURL = sandboxServ.URL
 
 	req := IAPRequest{
 		ReceiptData: "dummy data",
@@ -312,12 +308,6 @@ func sandboxSuccess() http.Handler {
 		}
 
 		w.WriteHeader(http.StatusOK)
-	})
-}
-
-func sandboxTimeout() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Do nothing and just dont return anything either
 	})
 }
 

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -205,7 +205,7 @@ func TestResponses(t *testing.T) {
 		},
 		// VerifyBadPayload
 		{
-			testServer: httptest.NewServer(serverWithResponse(http.StatusBadRequest, `{"status": 21002}`)),
+			testServer: httptest.NewServer(serverWithResponse(http.StatusOK, `{"status": 21002}`)),
 			expected: &IAPResponse{
 				Status: 21002,
 			},


### PR DESCRIPTION
According to https://developer.apple.com/library/content/technotes/tn2413/_index.html#//apple_ref/doc/uid/DTS40016228-CH1-RECEIPTURL

Always verify your receipt first with the production URL; proceed to verify with the sandbox URL if you receive a 21007 status code. Following this approach ensures that you do not have to switch between URLs while your application is being tested or reviewed in the sandbox or is live in the App Store.