### PR TITLE
Added cancellation date fields

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -145,8 +145,9 @@ type (
 	IAPResponseForIOS6 struct {
 		AutoRenewProductID     string         `json:"auto_renew_product_id"`
 		AutoRenewStatus        int            `json:"auto_renew_status"`
-		ExpirationIntent       string         `json:"expiration_intent"`
-		ISInBillingRetryPeriod string         `json:"is_in_billing_retry_period"`
+		CancellationReason     string         `json:"cancellation_reason,omitempty"`
+		ExpirationIntent       string         `json:"expiration_intent,omitempty"`
+		IsInBillingRetryPeriod string         `json:"is_in_billing_retry_period,omitempty"`
 		LatestReceiptInfo      ReceiptForIOS6 `json:"latest_expired_receipt_info"`
 		Receipt                ReceiptForIOS6 `json:"receipt"`
 		Status                 int            `json:"status"`
@@ -156,6 +157,7 @@ type (
 		AppItemID numericString `json:"app_item_id"`
 		BID       string        `json:"bid"`
 		BVRS      string        `json:"bvrs"`
+		CancellationDate
 		ExpiresDate
 		IsTrialPeriod        string `json:"is_trial_period"`
 		IsInIntroOfferPeriod string `json:"is_in_intro_offer_period"`


### PR DESCRIPTION
When the subscription is under billing problem, there are cancellation date fields in raw receipt.

```
{
  "auto_renew_product_id": "xxx",
  "auto_renew_status": 1,
  "cancellation_date": "2017-09-15 09:14:26 Etc/GMT",
  "cancellation_reason": "0",
  "expiration_intent": "2",
  "latest_expired_receipt_info": {
    "app_item_id": "xxx",
    "bid": "xxx",
    "bvrs": "xxx",
    "cancellation_date": "2017-09-15 09:14:26 Etc/GMT",
    "cancellation_date_ms": "1505466866000",
    "cancellation_date_pst": "2017-09-15 02:14:26 America/Los_Angeles",
    "expires_date": "1505170657000",
    "expires_date_formatted": "2017-09-11 22:57:37 Etc/GMT",
    "expires_date_formatted_pst": "2017-09-11 15:57:37 America/Los_Angeles",
    "item_id": "xxx",
    "original_purchase_date": "2016-08-11 22:57:40 Etc/GMT",
    "original_purchase_date_ms": "1470956260000",
    "original_purchase_date_pst": "2016-08-11 15:57:40 America/Los_Angeles",
    "original_transaction_id": "xxx",
    "product_id": "xxx",
    "purchase_date": "2017-08-11 22:57:37 Etc/GMT",
    "purchase_date_ms": "1502492257000",
    "purchase_date_pst": "2017-08-11 15:57:37 America/Los_Angeles",
    "quantity": "1",
    "transaction_id": "xxx",
    "unique_identifier": "xxx",
    "unique_vendor_identifier": "xxx",
    "web_order_line_item_id": "xxx"
  },
  "receipt": {
    "app_item_id": "xxx",
    "bid": "xxx",
    "bvrs": "xxx",
    "cancellation_date": "2017-09-15 09:14:26 Etc/GMT",
    "cancellation_date_ms": "1505466866000",
    "cancellation_date_pst": "2017-09-15 02:14:26 America/Los_Angeles",
    "expires_date": "1505170657000",
    "expires_date_formatted": "2017-09-11 22:57:37 Etc/GMT",
    "expires_date_formatted_pst": "2017-09-11 15:57:37 America/Los_Angeles",
    "item_id": "xxx",
    "original_purchase_date": "2016-08-11 22:57:40 Etc/GMT",
    "original_purchase_date_ms": "1470956260000",
    "original_purchase_date_pst": "2016-08-11 15:57:40 America/Los_Angeles",
    "original_transaction_id": "xxx",
    "product_id": "xxx",
    "purchase_date": "2017-08-11 22:57:37 Etc/GMT",
    "purchase_date_ms": "1502492257000",
    "purchase_date_pst": "2017-08-11 15:57:37 America/Los_Angeles",
    "quantity": "1",
    "transaction_id": "xxx",
    "unique_identifier": "xxx",
    "unique_vendor_identifier": "xxx",
    "version_external_identifier": "xxx",
    "web_order_line_item_id": "xxx"
  },
  "status": 21006
}
```