### PR TITLE
Support context package when requesting AppStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ func main() {
 	}
 
 	client := playstore.New(jsonKey)
-	resp, err := client.VerifySubscription("package", "subscriptionID", "purchaseToken")
+	ctx := context.Background()
+	resp, err := client.VerifySubscription(ctx, "package", "subscriptionID", "purchaseToken")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ func main() {
 		ReceiptData: "your receipt data encoded by base64",
 	}
 	resp := &appstore.IAPResponse{}
-	err := client.Verify(req, resp)
+	ctx := context.Background()
+	err := client.Verify(ctx, req, resp)
 }
 ```
 

--- a/playstore/validator.go
+++ b/playstore/validator.go
@@ -29,11 +29,11 @@ func SetTimeout(t time.Duration) {
 
 // The IABClient type is an interface to verify purchase token
 type IABClient interface {
-	VerifySubscription(string, string, string) (*androidpublisher.SubscriptionPurchase, error)
-	VerifyProduct(string, string, string) (*androidpublisher.ProductPurchase, error)
-	CancelSubscription(string, string, string) error
-	RefundSubscription(string, string, string) error
-	RevokeSubscription(string, string, string) error
+	VerifySubscription(context.Context, string, string, string) (*androidpublisher.SubscriptionPurchase, error)
+	VerifyProduct(context.Context, string, string, string) (*androidpublisher.ProductPurchase, error)
+	CancelSubscription(context.Context, string, string, string) error
+	RefundSubscription(context.Context, string, string, string) error
+	RevokeSubscription(context.Context, string, string, string) error
 }
 
 // The Client type implements VerifySubscription method
@@ -56,6 +56,7 @@ func New(jsonKey []byte) (Client, error) {
 
 // VerifySubscription verifies subscription status
 func (c *Client) VerifySubscription(
+	ctx context.Context,
 	packageName string,
 	subscriptionID string,
 	token string,
@@ -66,13 +67,14 @@ func (c *Client) VerifySubscription(
 	}
 
 	ps := androidpublisher.NewPurchasesSubscriptionsService(service)
-	result, err := ps.Get(packageName, subscriptionID, token).Do()
+	result, err := ps.Get(packageName, subscriptionID, token).Context(ctx).Do()
 
 	return result, err
 }
 
 // VerifyProduct verifies product status
 func (c *Client) VerifyProduct(
+	ctx context.Context,
 	packageName string,
 	productID string,
 	token string,
@@ -83,48 +85,48 @@ func (c *Client) VerifyProduct(
 	}
 
 	ps := androidpublisher.NewPurchasesProductsService(service)
-	result, err := ps.Get(packageName, productID, token).Do()
+	result, err := ps.Get(packageName, productID, token).Context(ctx).Do()
 
 	return result, err
 }
 
 // CancelSubscription cancels a user's subscription purchase.
-func (c *Client) CancelSubscription(packageName string, subscriptionID string, token string) error {
+func (c *Client) CancelSubscription(ctx context.Context, packageName string, subscriptionID string, token string) error {
 	service, err := androidpublisher.New(c.httpClient)
 	if err != nil {
 		return err
 	}
 
 	ps := androidpublisher.NewPurchasesSubscriptionsService(service)
-	err = ps.Cancel(packageName, subscriptionID, token).Do()
+	err = ps.Cancel(packageName, subscriptionID, token).Context(ctx).Do()
 
 	return err
 }
 
 // RefundSubscription refunds a user's subscription purchase, but the subscription remains valid
 // until its expiration time and it will continue to recur.
-func (c *Client) RefundSubscription(packageName string, subscriptionID string, token string) error {
+func (c *Client) RefundSubscription(ctx context.Context, packageName string, subscriptionID string, token string) error {
 	service, err := androidpublisher.New(c.httpClient)
 	if err != nil {
 		return err
 	}
 
 	ps := androidpublisher.NewPurchasesSubscriptionsService(service)
-	err = ps.Refund(packageName, subscriptionID, token).Do()
+	err = ps.Refund(packageName, subscriptionID, token).Context(ctx).Do()
 
 	return err
 }
 
 // RevokeSubscription refunds and immediately revokes a user's subscription purchase.
 // Access to the subscription will be terminated immediately and it will stop recurring.
-func (c *Client) RevokeSubscription(packageName string, subscriptionID string, token string) error {
+func (c *Client) RevokeSubscription(ctx context.Context, packageName string, subscriptionID string, token string) error {
 	service, err := androidpublisher.New(c.httpClient)
 	if err != nil {
 		return err
 	}
 
 	ps := androidpublisher.NewPurchasesSubscriptionsService(service)
-	err = ps.Revoke(packageName, subscriptionID, token).Do()
+	err = ps.Revoke(packageName, subscriptionID, token).Context(ctx).Do()
 
 	return err
 }

--- a/playstore/validator_test.go
+++ b/playstore/validator_test.go
@@ -1,6 +1,7 @@
 package playstore
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"reflect"
@@ -70,7 +71,8 @@ func TestVerifySubscription(t *testing.T) {
 	expected := "googleapi: Error 404: No application was found for the given package name., applicationNotFound"
 
 	client, _ := New(jsonKey)
-	_, err := client.VerifySubscription("package", "subscriptionID", "purchaseToken")
+	ctx := context.Background()
+	_, err := client.VerifySubscription(ctx, "package", "subscriptionID", "purchaseToken")
 
 	if err.Error() != expected {
 		t.Errorf("got %v\nwant %v", err, expected)
@@ -83,7 +85,8 @@ func TestVerifySubscriptionAndroidPublisherError(t *testing.T) {
 	t.Parallel()
 	client := Client{nil}
 	expected := errors.New("client is nil")
-	_, actual := client.VerifySubscription("package", "subscriptionID", "purchaseToken")
+	ctx := context.Background()
+	_, actual := client.VerifySubscription(ctx, "package", "subscriptionID", "purchaseToken")
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("got %v\nwant %v", actual, expected)
@@ -96,7 +99,8 @@ func TestVerifyProduct(t *testing.T) {
 	expected := "googleapi: Error 404: No application was found for the given package name., applicationNotFound"
 
 	client, _ := New(jsonKey)
-	_, err := client.VerifyProduct("package", "productID", "purchaseToken")
+	ctx := context.Background()
+	_, err := client.VerifyProduct(ctx, "package", "productID", "purchaseToken")
 
 	if err.Error() != expected {
 		t.Errorf("got %v", err)
@@ -109,7 +113,8 @@ func TestVerifyProductAndroidPublisherError(t *testing.T) {
 	t.Parallel()
 	client := Client{nil}
 	expected := errors.New("client is nil")
-	_, actual := client.VerifyProduct("package", "productID", "purchaseToken")
+	ctx := context.Background()
+	_, actual := client.VerifyProduct(ctx, "package", "productID", "purchaseToken")
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("got %v\nwant %v", actual, expected)
@@ -121,7 +126,8 @@ func TestCancelSubscription(t *testing.T) {
 	// Exception scenario
 	client := Client{nil}
 	expected := errors.New("client is nil")
-	actual := client.CancelSubscription("package", "productID", "purchaseToken")
+	ctx := context.Background()
+	actual := client.CancelSubscription(ctx, "package", "productID", "purchaseToken")
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("got %v\nwant %v", actual, expected)
@@ -129,7 +135,7 @@ func TestCancelSubscription(t *testing.T) {
 
 	client, _ = New(jsonKey)
 	expectedStr := "googleapi: Error 404: No application was found for the given package name., applicationNotFound"
-	actual = client.CancelSubscription("package", "productID", "purchaseToken")
+	actual = client.CancelSubscription(ctx, "package", "productID", "purchaseToken")
 
 	if actual.Error() != expectedStr {
 		t.Errorf("got %v\nwant %v", actual, expectedStr)
@@ -143,7 +149,8 @@ func TestRefundSubscription(t *testing.T) {
 	// Exception scenario
 	client := Client{nil}
 	expected := errors.New("client is nil")
-	actual := client.RefundSubscription("package", "productID", "purchaseToken")
+	ctx := context.Background()
+	actual := client.RefundSubscription(ctx, "package", "productID", "purchaseToken")
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("got %v\nwant %v", actual, expected)
@@ -151,7 +158,7 @@ func TestRefundSubscription(t *testing.T) {
 
 	client, _ = New(jsonKey)
 	expectedStr := "googleapi: Error 404: No application was found for the given package name., applicationNotFound"
-	actual = client.RefundSubscription("package", "productID", "purchaseToken")
+	actual = client.RefundSubscription(ctx, "package", "productID", "purchaseToken")
 
 	if actual.Error() != expectedStr {
 		t.Errorf("got %v\nwant %v", actual, expectedStr)
@@ -165,7 +172,8 @@ func TestRevokeSubscription(t *testing.T) {
 	// Exception scenario
 	client := Client{nil}
 	expected := errors.New("client is nil")
-	actual := client.RevokeSubscription("package", "productID", "purchaseToken")
+	ctx := context.Background()
+	actual := client.RevokeSubscription(ctx, "package", "productID", "purchaseToken")
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("got %v\nwant %v", actual, expected)
@@ -173,7 +181,7 @@ func TestRevokeSubscription(t *testing.T) {
 
 	client, _ = New(jsonKey)
 	expectedStr := "googleapi: Error 404: No application was found for the given package name., applicationNotFound"
-	actual = client.RevokeSubscription("package", "productID", "purchaseToken")
+	actual = client.RevokeSubscription(ctx, "package", "productID", "purchaseToken")
 
 	if actual.Error() != expectedStr {
 		t.Errorf("got %v\nwant %v", actual, expectedStr)


### PR DESCRIPTION
resolve #61 

The following test ensures that the cancellation works.
https://github.com/awa/go-iap/compare/master...jun06t:context?expand=1#diff-821c99a26e8982efee8b6b0c363368f9R140