### PR TITLE
Added client timeout because http.DefaultClient doesn't have timeout

### DIFF
--- a/amazon/validator.go
+++ b/amazon/validator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 )
 
 const (
@@ -55,9 +56,11 @@ type Client struct {
 // New creates a client object
 func New(secret string) *Client {
 	client := &Client{
-		URL:     getSandboxURL(),
-		Secret:  secret,
-		httpCli: http.DefaultClient,
+		URL:    getSandboxURL(),
+		Secret: secret,
+		httpCli: &http.Client{
+			Timeout: 10 * time.Second,
+		},
 	}
 	if os.Getenv("IAP_ENVIRONMENT") == "production" {
 		client.URL = ProductionURL

--- a/amazon/validator_test.go
+++ b/amazon/validator_test.go
@@ -60,9 +60,11 @@ func TestHandle400Error(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	expected := &Client{
-		URL:     SandboxURL,
-		Secret:  "developerSecret",
-		httpCli: http.DefaultClient,
+		URL:    SandboxURL,
+		Secret: "developerSecret",
+		httpCli: &http.Client{
+			Timeout: 10 * time.Second,
+		},
 	}
 
 	actual := New("developerSecret")
@@ -73,9 +75,11 @@ func TestNew(t *testing.T) {
 
 func TestNewWithEnvironment(t *testing.T) {
 	expected := &Client{
-		URL:     ProductionURL,
-		Secret:  "developerSecret",
-		httpCli: http.DefaultClient,
+		URL:    ProductionURL,
+		Secret: "developerSecret",
+		httpCli: &http.Client{
+			Timeout: 10 * time.Second,
+		},
 	}
 
 	os.Setenv("IAP_ENVIRONMENT", "production")

--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"time"
 )
 
 const (
@@ -78,7 +79,9 @@ func New() *Client {
 	client := &Client{
 		ProductionURL: ProductionURL,
 		SandboxURL:    SandboxURL,
-		httpCli:       http.DefaultClient,
+		httpCli: &http.Client{
+			Timeout: 10 * time.Second,
+		},
 	}
 	return client
 }

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -90,7 +90,9 @@ func TestNew(t *testing.T) {
 	expected := &Client{
 		ProductionURL: ProductionURL,
 		SandboxURL:    SandboxURL,
-		httpCli:       http.DefaultClient,
+		httpCli: &http.Client{
+			Timeout: 10 * time.Second,
+		},
 	}
 
 	actual := New()

--- a/playstore/validator.go
+++ b/playstore/validator.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -26,14 +27,14 @@ type IABClient interface {
 
 // The Client type implements VerifySubscription method
 type Client struct {
-	httpClient *http.Client
+	httpCli *http.Client
 }
 
 // New returns http client which includes the credentials to access androidpublisher API.
 // You should create a service account for your project at
 // https://console.developers.google.com and download a JSON key file to set this argument.
 func New(jsonKey []byte) (*Client, error) {
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, http.DefaultClient)
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Timeout: 10 * time.Second})
 
 	conf, err := google.JWTConfigFromJSON(jsonKey, androidpublisher.AndroidpublisherScope)
 
@@ -59,7 +60,7 @@ func (c *Client) VerifySubscription(
 	subscriptionID string,
 	token string,
 ) (*androidpublisher.SubscriptionPurchase, error) {
-	service, err := androidpublisher.New(c.httpClient)
+	service, err := androidpublisher.New(c.httpCli)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +78,7 @@ func (c *Client) VerifyProduct(
 	productID string,
 	token string,
 ) (*androidpublisher.ProductPurchase, error) {
-	service, err := androidpublisher.New(c.httpClient)
+	service, err := androidpublisher.New(c.httpCli)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func (c *Client) VerifyProduct(
 
 // CancelSubscription cancels a user's subscription purchase.
 func (c *Client) CancelSubscription(ctx context.Context, packageName string, subscriptionID string, token string) error {
-	service, err := androidpublisher.New(c.httpClient)
+	service, err := androidpublisher.New(c.httpCli)
 	if err != nil {
 		return err
 	}
@@ -104,7 +105,7 @@ func (c *Client) CancelSubscription(ctx context.Context, packageName string, sub
 // RefundSubscription refunds a user's subscription purchase, but the subscription remains valid
 // until its expiration time and it will continue to recur.
 func (c *Client) RefundSubscription(ctx context.Context, packageName string, subscriptionID string, token string) error {
-	service, err := androidpublisher.New(c.httpClient)
+	service, err := androidpublisher.New(c.httpCli)
 	if err != nil {
 		return err
 	}
@@ -118,7 +119,7 @@ func (c *Client) RefundSubscription(ctx context.Context, packageName string, sub
 // RevokeSubscription refunds and immediately revokes a user's subscription purchase.
 // Access to the subscription will be terminated immediately and it will stop recurring.
 func (c *Client) RevokeSubscription(ctx context.Context, packageName string, subscriptionID string, token string) error {
-	service, err := androidpublisher.New(c.httpClient)
+	service, err := androidpublisher.New(c.httpCli)
 	if err != nil {
 		return err
 	}

--- a/playstore/validator_test.go
+++ b/playstore/validator_test.go
@@ -37,7 +37,7 @@ func TestNew(t *testing.T) {
 	expected := "oauth2: cannot fetch token: 401 Unauthorized\nResponse: {\n  \"error\" : \"invalid_client\",\n  \"error_description\" : \"The OAuth client was invalid.\"\n}"
 
 	actual, _ := New(dummyKey)
-	val := actual.httpClient.Transport.(*oauth2.Transport)
+	val := actual.httpCli.Transport.(*oauth2.Transport)
 	token, err := val.Source.Token()
 	if token != nil {
 		t.Errorf("got %#v", token)
@@ -48,7 +48,7 @@ func TestNew(t *testing.T) {
 
 	// TODO Normal scenario
 	actual, _ = New(jsonKey)
-	val = actual.httpClient.Transport.(*oauth2.Transport)
+	val = actual.httpCli.Transport.(*oauth2.Transport)
 	token, err = val.Source.Token()
 	if err != nil {
 		t.Errorf("got %#v", err)
@@ -62,7 +62,7 @@ func TestNewWithClient(t *testing.T) {
 	httpClient := urlfetch.Client(ctx)
 
 	cli, _ := NewWithClient(dummyKey, httpClient)
-	tr, _ := cli.httpClient.Transport.(*oauth2.Transport)
+	tr, _ := cli.httpCli.Transport.(*oauth2.Transport)
 
 	if !reflect.DeepEqual(tr.Base, httpClient.Transport) {
 		t.Errorf("transport should be urlfetch's one")


### PR DESCRIPTION
The http document says "A Timeout of zero means no timeout".

>         // Timeout specifies a time limit for requests made by this
>         // Client. The timeout includes connection time, any
>         // redirects, and reading the response body. The timer remains
>         // running after Get, Head, Post, or Do return and will
>         // interrupt reading of the Response.Body.
>         //
>         // A Timeout of zero means no timeout.

https://golang.org/pkg/net/http/#Clientn

And DefaultClient is empty struct of Client.
```
var DefaultClient = &Client{}
```
So DefaultClient doesn't have timeout. It may stress the system heavily.