### PR TITLE
Add `pending_renewal_info.original_transaction_id` for Apple's receipt

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -119,6 +119,7 @@ type (
 		SubscriptionAutoRenewStatus    string `json:"auto_renew_status"`
 		SubscriptionPriceConsentStatus string `json:"price_consent_status"`
 		ProductID                      string `json:"product_id"`
+		OriginalTransactionID          string `json:"original_transaction_id"`
 	}
 
 	// The IAPResponse type has the response properties


### PR DESCRIPTION
- Since `original_transaction_id` included in `pending_renewal_info` is not defined, it was added.