### PR TITLE
Adding unified receipt to the Apple S2S notification

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -85,17 +85,17 @@ type (
 
 	// The InApp type has the receipt attributes
 	InApp struct {
-		Quantity              string `json:"quantity"`
-		ProductID             string `json:"product_id"`
-		TransactionID         string `json:"transaction_id"`
-		OriginalTransactionID string `json:"original_transaction_id"`
-		WebOrderLineItemID    string `json:"web_order_line_item_id,omitempty"`
-
-		IsTrialPeriod               string `json:"is_trial_period"`
-		IsInIntroOfferPeriod        string `json:"is_in_intro_offer_period,omitempty"`
-		IsUpgraded                  string `json:"is_upgraded"`
+		Quantity                    string `json:"quantity"`
+		ProductID                   string `json:"product_id"`
+		TransactionID               string `json:"transaction_id"`
+		OriginalTransactionID       string `json:"original_transaction_id"`
+		WebOrderLineItemID          string `json:"web_order_line_item_id,omitempty"`
 		PromotionalOfferID          string `json:"promotional_offer_id"`
 		SubscriptionGroupIdentifier string `json:"subscription_group_identifier"`
+
+		IsTrialPeriod        string `json:"is_trial_period"`
+		IsInIntroOfferPeriod string `json:"is_in_intro_offer_period,omitempty"`
+		IsUpgraded           string `json:"is_upgraded"`
 
 		ExpiresDate
 

--- a/appstore/model.go
+++ b/appstore/model.go
@@ -91,8 +91,12 @@ type (
 		OriginalTransactionID string `json:"original_transaction_id"`
 		WebOrderLineItemID    string `json:"web_order_line_item_id,omitempty"`
 
-		IsTrialPeriod        string `json:"is_trial_period"`
-		IsInIntroOfferPeriod string `json:"is_in_intro_offer_period,omitempty"`
+		IsTrialPeriod               string `json:"is_trial_period"`
+		IsInIntroOfferPeriod        string `json:"is_in_intro_offer_period,omitempty"`
+		IsUpgraded                  string `json:"is_upgraded"`
+		PromotionalOfferID          string `json:"promotional_offer_id"`
+		SubscriptionGroupIdentifier string `json:"subscription_group_identifier"`
+
 		ExpiresDate
 
 		PurchaseDate

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -57,11 +57,8 @@ type NotificationReceipt struct {
 }
 
 type NotificationUnifiedReceipt struct {
-	Status string `json:"status"`
-
-	// For production we will get "Production" instead of "PROD"
-	Environment NotificationEnvironment `json:"environment"`
-
+	Status             string               `json:"status"`
+	Environment        Environment          `json:"environment"`
 	LatestReceipt      string               `json:"latest_receipt"`
 	LatestReceiptInfo  []InApp              `json:"latest_receipt_info"`
 	PendingRenewalInfo []PendingRenewalInfo `json:"pending_renewal_info,omitempty"`

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -35,23 +35,20 @@ type NotificationExpiresDate struct {
 }
 
 type NotificationReceipt struct {
-	UniqueIdentifier            string `json:"unique_identifier"`
-	AppItemID                   string `json:"app_item_id"`
-	Quantity                    string `json:"quantity"`
-	VersionExternalIdentifier   string `json:"version_external_identifier"`
-	UniqueVendorIdentifier      string `json:"unique_vendor_identifier"`
-	WebOrderLineItemID          string `json:"web_order_line_item_id"`
-	ItemID                      string `json:"item_id"`
-	ProductID                   string `json:"product_id"`
-	BID                         string `json:"bid"`
-	BVRS                        string `json:"bvrs"`
-	TransactionID               string `json:"transaction_id"`
-	OriginalTransactionID       string `json:"original_transaction_id"`
-	IsTrialPeriod               string `json:"is_trial_period"`
-	IsInIntroOfferPeriod        string `json:"is_in_intro_offer_period"`
-	IsUpgraded                  string `json:"is_upgraded"`
-	PromotionalOfferID          string `json:"promotional_offer_id"`
-	SubscriptionGroupIdentifier string `json:"subscription_group_identifier"`
+	UniqueIdentifier          string `json:"unique_identifier"`
+	AppItemID                 string `json:"app_item_id"`
+	Quantity                  string `json:"quantity"`
+	VersionExternalIdentifier string `json:"version_external_identifier"`
+	UniqueVendorIdentifier    string `json:"unique_vendor_identifier"`
+	WebOrderLineItemID        string `json:"web_order_line_item_id"`
+	ItemID                    string `json:"item_id"`
+	ProductID                 string `json:"product_id"`
+	BID                       string `json:"bid"`
+	BVRS                      string `json:"bvrs"`
+	TransactionID             string `json:"transaction_id"`
+	OriginalTransactionID     string `json:"original_transaction_id"`
+	IsTrialPeriod             string `json:"is_trial_period"`
+	IsInIntroOfferPeriod      string `json:"is_in_intro_offer_period"`
 
 	PurchaseDate
 	OriginalPurchaseDate
@@ -65,9 +62,9 @@ type NotificationUnifiedReceipt struct {
 	// For production we will get "Production" instead of "PROD"
 	Environment NotificationEnvironment `json:"environment"`
 
-	LatestReceipt      string                `json:"latest_receipt"`
-	LatestReceiptInfo  []NotificationReceipt `json:"latest_receipt_info"`
-	PendingRenewalInfo []PendingRenewalInfo  `json:"pending_renewal_info,omitempty"`
+	LatestReceipt      string               `json:"latest_receipt"`
+	LatestReceiptInfo  []InApp              `json:"latest_receipt_info"`
+	PendingRenewalInfo []PendingRenewalInfo `json:"pending_renewal_info,omitempty"`
 }
 
 type SubscriptionNotification struct {

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -9,7 +9,10 @@ const (
 	// Subscription was canceled by Apple customer support.
 	NotificationTypeCancel NotificationType = "CANCEL"
 	// Automatic renewal was successful for an expired subscription.
+	// Deprecated: DID_RECOVER should be used instead of RENEWAL
 	NotificationTypeRenewal NotificationType = "RENEWAL"
+	// Expired subscription recovered through a billing retry.
+	NotificationTypeDidRecover NotificationType = "DID_RECOVER"
 	// Customer renewed a subscription interactively after it lapsed.
 	NotificationTypeInteractiveRenewal NotificationType = "INTERACTIVE_RENEWAL"
 	// Customer changed the plan that takes affect at the next subscription renewal. Current active plan is not affected.
@@ -32,25 +35,39 @@ type NotificationExpiresDate struct {
 }
 
 type NotificationReceipt struct {
-	UniqueIdentifier          string `json:"unique_identifier"`
-	AppItemID                 string `json:"app_item_id"`
-	Quantity                  string `json:"quantity"`
-	VersionExternalIdentifier string `json:"version_external_identifier"`
-	UniqueVendorIdentifier    string `json:"unique_vendor_identifier"`
-	WebOrderLineItemID        string `json:"web_order_line_item_id"`
-	ItemID                    string `json:"item_id"`
-	ProductID                 string `json:"product_id"`
-	BID                       string `json:"bid"`
-	BVRS                      string `json:"bvrs"`
-	TransactionID             string `json:"transaction_id"`
-	OriginalTransactionID     string `json:"original_transaction_id"`
-	IsTrialPeriod             string `json:"is_trial_period"`
-	IsInIntroOfferPeriod      string `json:"is_in_intro_offer_period"`
+	UniqueIdentifier            string `json:"unique_identifier"`
+	AppItemID                   string `json:"app_item_id"`
+	Quantity                    string `json:"quantity"`
+	VersionExternalIdentifier   string `json:"version_external_identifier"`
+	UniqueVendorIdentifier      string `json:"unique_vendor_identifier"`
+	WebOrderLineItemID          string `json:"web_order_line_item_id"`
+	ItemID                      string `json:"item_id"`
+	ProductID                   string `json:"product_id"`
+	BID                         string `json:"bid"`
+	BVRS                        string `json:"bvrs"`
+	TransactionID               string `json:"transaction_id"`
+	OriginalTransactionID       string `json:"original_transaction_id"`
+	IsTrialPeriod               string `json:"is_trial_period"`
+	IsInIntroOfferPeriod        string `json:"is_in_intro_offer_period"`
+	IsUpgraded                  string `json:"is_upgraded"`
+	PromotionalOfferID          string `json:"promotional_offer_id"`
+	SubscriptionGroupIdentifier string `json:"subscription_group_identifier"`
 
 	PurchaseDate
 	OriginalPurchaseDate
 	NotificationExpiresDate
 	CancellationDate
+}
+
+type NotificationUnifiedReceipt struct {
+	Status string `json:"status"`
+
+	// For production we will get "Production" instead of "PROD"
+	Environment NotificationEnvironment `json:"environment"`
+
+	LatestReceipt      string                `json:"latest_receipt"`
+	LatestReceiptInfo  []NotificationReceipt `json:"latest_receipt_info"`
+	PendingRenewalInfo []PendingRenewalInfo  `json:"pending_renewal_info,omitempty"`
 }
 
 type SubscriptionNotification struct {
@@ -79,6 +96,9 @@ type SubscriptionNotification struct {
 	// Not posted for notification_type CANCEL.
 	LatestReceipt     string              `json:"latest_receipt"`
 	LatestReceiptInfo NotificationReceipt `json:"latest_receipt_info"`
+
+	// In the new notifications above properties latest_receipt, latest_receipt_info are moved under this one
+	UnifiedReceipt NotificationUnifiedReceipt `json:"unified_receipt"`
 
 	// Posted only if the notification_type is RENEWAL or CANCEL or if renewal failed and subscription expired.
 	LatestExpiredReceipt     string              `json:"latest_expired_receipt"`


### PR DESCRIPTION
Apple added a new property `unified_receipt` to their S2S notification that should be used instead of existing properties:
https://developer.apple.com/news/?id=11222019a
https://developer.apple.com/documentation/appstoreservernotifications/unified_receipt

Also, added some missing properties to `InApp` and new `DID_RECOVER` notification type that should be used instead of `RENEWAL`.