### PR TITLE
Http error handling

### DIFF
--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -295,14 +295,14 @@ func (errReader) Read(p []byte) (n int, err error) {
 
 func serverWithResponse(statusCode int, response string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if "POST" == r.Method {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(response))
-			return
-		} else {
+		if "POST" != r.Method {
+			w.WriteHeader(http.StatusMethodNotAllowed)
 			w.Write([]byte(`unsupported request`))
+			return
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(statusCode)
+		w.Write([]byte(response))
 	})
 }


### PR DESCRIPTION
When Apple's API returns a 503 error with a non-JSON body, we were getting some confusing errors:
    
        appstore: *json.SyntaxError: invalid character '<' looking for beginning of value
    
It was trying to parse the body:

    <html><body><b>Http/1.1 Service Unavailable</b></body> </html>

This changes the Verify() API to return an error when there's a 500+ status, and adds a `Temporary() bool` method based on errors in the standard library's net package. (We're using it to decide whether to retry/alert on a failed request.)
