### PR TITLE
appstore: Set IsUpgraded as omitempty

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -95,7 +95,7 @@ type (
 
 		IsTrialPeriod        string `json:"is_trial_period"`
 		IsInIntroOfferPeriod string `json:"is_in_intro_offer_period,omitempty"`
-		IsUpgraded           string `json:"is_upgraded"`
+		IsUpgraded           string `json:"is_upgraded,omitempty"`
 
 		ExpiresDate
 


### PR DESCRIPTION
As documented in https://developer.apple.com/documentation/appstorereceipts/responsebody/latest_receipt_info: 

> This field is only present for upgrade transactions.