### PR TITLE
Fixing NotificationUnifiedReceipt status type

### DIFF
--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -57,7 +57,7 @@ type NotificationReceipt struct {
 }
 
 type NotificationUnifiedReceipt struct {
-	Status             string               `json:"status"`
+	Status             int                  `json:"status"`
 	Environment        Environment          `json:"environment"`
 	LatestReceipt      string               `json:"latest_receipt"`
 	LatestReceiptInfo  []InApp              `json:"latest_receipt_info"`


### PR DESCRIPTION
Since few days ago we noticed that Apple started returning `Status` of `NotificationUnifiedReceipt` as integer instead of string and so now we are getting errors like:
```
json: cannot unmarshal number into Go struct field NotificationUnifiedReceipt.unified_receipt.status of type string
```

Unified receipt docs: https://developer.apple.com/documentation/appstoreservernotifications/unified_receipt