### PR TITLE
increase default timeout for client

### DIFF
--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -91,7 +91,7 @@ func New() *Client {
 		ProductionURL: ProductionURL,
 		SandboxURL:    SandboxURL,
 		httpCli: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: 30 * time.Second,
 		},
 	}
 	return client

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -96,7 +96,7 @@ func TestNew(t *testing.T) {
 		ProductionURL: ProductionURL,
 		SandboxURL:    SandboxURL,
 		httpCli: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: 30 * time.Second,
 		},
 	}
 


### PR DESCRIPTION
Apple servers sometimes takes more than the default time causing client timeouts, increase the default timeout to cater increases response times.

https://github.com/awa/go-iap/issues/123