### PR TITLE
Fixing Apple OriginalTransactionID type

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -207,7 +207,7 @@ type (
 		ItemID               string `json:"item_id"`
 		ProductID            string `json:"product_id"`
 		PurchaseDate
-		OriginalTransactionID int64 `json:"original_transaction_id"`
+		OriginalTransactionID numericString `json:"original_transaction_id"`
 		OriginalPurchaseDate
 		Quantity                  string        `json:"quantity"`
 		TransactionID             string        `json:"transaction_id"`

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -54,20 +54,20 @@ type NotificationExpiresDate struct {
 
 // NotificationReceipt is struct
 type NotificationReceipt struct {
-	UniqueIdentifier          string `json:"unique_identifier"`
-	AppItemID                 string `json:"app_item_id"`
-	Quantity                  string `json:"quantity"`
-	VersionExternalIdentifier string `json:"version_external_identifier"`
-	UniqueVendorIdentifier    string `json:"unique_vendor_identifier"`
-	WebOrderLineItemID        string `json:"web_order_line_item_id"`
-	ItemID                    string `json:"item_id"`
-	ProductID                 string `json:"product_id"`
-	BID                       string `json:"bid"`
-	BVRS                      string `json:"bvrs"`
-	TransactionID             string `json:"transaction_id"`
-	OriginalTransactionID     int64  `json:"original_transaction_id"`
-	IsTrialPeriod             string `json:"is_trial_period"`
-	IsInIntroOfferPeriod      string `json:"is_in_intro_offer_period"`
+	UniqueIdentifier          string        `json:"unique_identifier"`
+	AppItemID                 string        `json:"app_item_id"`
+	Quantity                  string        `json:"quantity"`
+	VersionExternalIdentifier string        `json:"version_external_identifier"`
+	UniqueVendorIdentifier    string        `json:"unique_vendor_identifier"`
+	WebOrderLineItemID        string        `json:"web_order_line_item_id"`
+	ItemID                    string        `json:"item_id"`
+	ProductID                 string        `json:"product_id"`
+	BID                       string        `json:"bid"`
+	BVRS                      string        `json:"bvrs"`
+	TransactionID             string        `json:"transaction_id"`
+	OriginalTransactionID     numericString `json:"original_transaction_id"`
+	IsTrialPeriod             string        `json:"is_trial_period"`
+	IsInIntroOfferPeriod      string        `json:"is_in_intro_offer_period"`
 
 	PurchaseDate
 	OriginalPurchaseDate
@@ -91,9 +91,9 @@ type SubscriptionNotification struct {
 	NotificationType NotificationType        `json:"notification_type"`
 
 	// Not show in raw notify body
-	Password              string `json:"password"`
-	OriginalTransactionID int64  `json:"original_transaction_id"`
-	AutoRenewAdamID       string `json:"auto_renew_adam_id"`
+	Password              string        `json:"password"`
+	OriginalTransactionID numericString `json:"original_transaction_id"`
+	AutoRenewAdamID       string        `json:"auto_renew_adam_id"`
 
 	// The primary key for identifying a subscription purchase.
 	// Posted only if the notification_type is CANCEL.


### PR DESCRIPTION
Since yesterday we noticed that Apple is sending `OriginalTransactionID` sometimes as a string and sometimes as an integer.
So, I replaced `int64` with `numericString` which can handle such cases.

Related to: https://github.com/awa/go-iap/pull/157