### PR TITLE
Iap 259 fix type difference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ _testmain.go
 *.prof
 
 coverage.txt
+.idea/*

--- a/appstore/model.go
+++ b/appstore/model.go
@@ -158,14 +158,16 @@ type (
 
 	// IAPResponseForIOS6 is iOS 6 style receipt schema.
 	IAPResponseForIOS6 struct {
-		AutoRenewProductID     string         `json:"auto_renew_product_id"`
-		AutoRenewStatus        int            `json:"auto_renew_status"`
-		CancellationReason     string         `json:"cancellation_reason,omitempty"`
-		ExpirationIntent       string         `json:"expiration_intent,omitempty"`
-		IsInBillingRetryPeriod string         `json:"is_in_billing_retry_period,omitempty"`
-		LatestReceiptInfo      ReceiptForIOS6 `json:"latest_expired_receipt_info"`
-		Receipt                ReceiptForIOS6 `json:"receipt"`
-		Status                 int            `json:"status"`
+		AutoRenewProductID       string         `json:"auto_renew_product_id"`
+		AutoRenewStatus          int            `json:"auto_renew_status"`
+		CancellationReason       string         `json:"cancellation_reason,omitempty"`
+		ExpirationIntent         string         `json:"expiration_intent,omitempty"`
+		IsInBillingRetryPeriod   string         `json:"is_in_billing_retry_period,omitempty"`
+		Receipt                  ReceiptForIOS6 `json:"receipt"`
+		LatestExpiredReceiptInfo ReceiptForIOS6 `json:"latest_expired_receipt_info"`
+		LatestReceipt            string         `json:"latest_receipt"`
+		LatestReceiptInfo        ReceiptForIOS6 `json:"latest_receipt_info"`
+		Status                   int            `json:"status"`
 	}
 
 	ReceiptForIOS6 struct {

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -21,6 +21,8 @@ const (
 	NotificationTypeDidChangeRenewalStatus NotificationType = "DID_CHANGE_RENEWAL_STATUS"
 	// Subscription failed to renew due to a billing issue.
 	NotificationTypeDidFailToRenew NotificationType = "DID_FAIL_TO_RENEW"
+	// AppleCare successfully refunded the transaction for a consumable, non-consumable, or a non-renewing subscription
+	NotificationTypeRefund NotificationType = "REFUND"
 )
 
 type NotificationEnvironment string
@@ -98,7 +100,7 @@ type SubscriptionNotification struct {
 	// In the new notifications above properties latest_receipt, latest_receipt_info are moved under this one
 	UnifiedReceipt NotificationUnifiedReceipt `json:"unified_receipt"`
 
-	// Posted only if the notification_type is RENEWAL or CANCEL or if renewal failed and subscription expired.
+	// Posted only if the notification_type is CANCEL or DID_FAIL_TO_RENEW or if renewal failed and subscription expired.
 	// Deprecated: see details: https://developer.apple.com/documentation/appstoreservernotifications/ .
 	LatestExpiredReceipt string `json:"latest_expired_receipt"`
 	// Deprecated: see details: https://developer.apple.com/documentation/appstoreservernotifications/ .

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -23,6 +23,10 @@ const (
 	NotificationTypeDidFailToRenew NotificationType = "DID_FAIL_TO_RENEW"
 	// AppleCare successfully refunded the transaction for a consumable, non-consumable, or a non-renewing subscription
 	NotificationTypeRefund NotificationType = "REFUND"
+	// App Store has started asking the customer to consent to your app’s subscription price increase
+	NotificationTypePriceIncreaseConsent NotificationType = "PRICE_INCREASE_CONSENT"
+	// Customer’s subscription has successfully auto-renewed for a new transaction period.
+	NotificationTypeDidRenew NotificationType = "DID_RENEW"
 )
 
 type NotificationEnvironment string

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -43,20 +43,20 @@ type NotificationExpiresDate struct {
 }
 
 type NotificationReceipt struct {
-	UniqueIdentifier          string `json:"unique_identifier"`
-	AppItemID                 string `json:"app_item_id"`
-	Quantity                  string `json:"quantity"`
-	VersionExternalIdentifier string `json:"version_external_identifier"`
-	UniqueVendorIdentifier    string `json:"unique_vendor_identifier"`
-	WebOrderLineItemID        string `json:"web_order_line_item_id"`
-	ItemID                    string `json:"item_id"`
-	ProductID                 string `json:"product_id"`
-	BID                       string `json:"bid"`
-	BVRS                      string `json:"bvrs"`
-	TransactionID             string `json:"transaction_id"`
-	OriginalTransactionID     string `json:"original_transaction_id"`
-	IsTrialPeriod             string `json:"is_trial_period"`
-	IsInIntroOfferPeriod      string `json:"is_in_intro_offer_period"`
+	UniqueIdentifier          string        `json:"unique_identifier"`
+	AppItemID                 string        `json:"app_item_id"`
+	Quantity                  string        `json:"quantity"`
+	VersionExternalIdentifier string        `json:"version_external_identifier"`
+	UniqueVendorIdentifier    string        `json:"unique_vendor_identifier"`
+	WebOrderLineItemID        string        `json:"web_order_line_item_id"`
+	ItemID                    string        `json:"item_id"`
+	ProductID                 string        `json:"product_id"`
+	BID                       string        `json:"bid"`
+	BVRS                      string        `json:"bvrs"`
+	TransactionID             string        `json:"transaction_id"`
+	OriginalTransactionID     numericString `json:"original_transaction_id"`
+	IsTrialPeriod             string        `json:"is_trial_period"`
+	IsInIntroOfferPeriod      string        `json:"is_in_intro_offer_period"`
 
 	PurchaseDate
 	OriginalPurchaseDate
@@ -77,9 +77,9 @@ type SubscriptionNotification struct {
 	NotificationType NotificationType        `json:"notification_type"`
 
 	// Not show in raw notify body
-	Password              string `json:"password"`
-	OriginalTransactionID string `json:"original_transaction_id"`
-	AutoRenewAdamID       string `json:"auto_renew_adam_id"`
+	Password              string        `json:"password"`
+	OriginalTransactionID numericString `json:"original_transaction_id"`
+	AutoRenewAdamID       string        `json:"auto_renew_adam_id"`
 
 	// The primary key for identifying a subscription purchase.
 	// Posted only if the notification_type is CANCEL.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/awa/go-iap
+module github.com/Enflick/go-iap
 
 go 1.12
 

--- a/playstore/notification.go
+++ b/playstore/notification.go
@@ -1,39 +1,63 @@
 package playstore
 
-// DeveloperNotification is sent by a Pub/Sub topic.
-// Detailed description is following.
-// https://developer.android.com/google/play/billing/realtime_developer_notifications.html#json_specification
-type DeveloperNotification struct {
-	Version                  string                   `json:"version"`
-	PackageName              string                   `json:"packageName"`
-	EventTimeMillis          string                   `json:"eventTimeMillis"`
-	SubscriptionNotification SubscriptionNotification `json:"subscriptionNotification,omitempty"`
-	TestNotification         SubscriptionNotification `json:"testNotification,omitempty"`
-}
-
-// SubscriptionNotification has subscription status as notificationType, toke and subscription id
-// to confirm status by calling Google Android Publisher API.
-type SubscriptionNotification struct {
-	Version          string           `json:"version"`
-	NotificationType NotificationType `json:"notificationType,omitempty"`
-	PurchaseToken    string           `json:"purchaseToken,omitempty"`
-	SubscriptionID   string           `json:"subscriptionId,omitempty"`
-}
-
-type NotificationType int
+// https://developer.android.com/google/play/billing/rtdn-reference#sub
+type SubscriptionNotificationType int
 
 const (
-	NotificationTypeRecovered NotificationType = iota + 1
-	NotificationTypeRenewed
-	NotificationTypeCanceled
-	NotificationTypePurchased
-	NotificationTypeAccountHold
-	NotificationTypeGracePeriod
-	NotificationTypeRestarted
-	NotificationTypePriceChangeConfirmed
-	NotificationTypeDeferred
-	NotificationTypePaused
-	NotificationTypePauseScheduleChanged
-	NotificationTypeRevoked
-	NotificationTypeExpired
+	SubscriptionNotificationTypeRecovered SubscriptionNotificationType = iota + 1
+	SubscriptionNotificationTypeRenewed
+	SubscriptionNotificationTypeCanceled
+	SubscriptionNotificationTypePurchased
+	SubscriptionNotificationTypeAccountHold
+	SubscriptionNotificationTypeGracePeriod
+	SubscriptionNotificationTypeRestarted
+	SubscriptionNotificationTypePriceChangeConfirmed
+	SubscriptionNotificationTypeDeferred
+	SubscriptionNotificationTypePaused
+	SubscriptionNotificationTypePauseScheduleChanged
+	SubscriptionNotificationTypeRevoked
+	SubscriptionNotificationTypeExpired
 )
+
+// https://developer.android.com/google/play/billing/rtdn-reference#one-time
+type OneTimeProductNotificationType int
+
+const (
+	OneTimeProductNotificationTypePurchased OneTimeProductNotificationType = iota + 1
+	OneTimeProductNotificationTypeCanceled
+)
+
+// DeveloperNotification is sent by a Pub/Sub topic.
+// Detailed description is following.
+// https://developer.android.com/google/play/billing/rtdn-reference#json_specification
+type DeveloperNotification struct {
+	Version                    string                     `json:"version"`
+	PackageName                string                     `json:"packageName"`
+	EventTimeMillis            string                     `json:"eventTimeMillis"`
+	SubscriptionNotification   SubscriptionNotification   `json:"subscriptionNotification,omitempty"`
+	OneTimeProductNotification OneTimeProductNotification `json:"oneTimeProductNotification,omitempty"`
+	TestNotification           TestNotification           `json:"testNotification,omitempty"`
+}
+
+// SubscriptionNotification has subscription status as notificationType, token and subscription id
+// to confirm status by calling Google Android Publisher API.
+type SubscriptionNotification struct {
+	Version          string                       `json:"version"`
+	NotificationType SubscriptionNotificationType `json:"notificationType,omitempty"`
+	PurchaseToken    string                       `json:"purchaseToken,omitempty"`
+	SubscriptionID   string                       `json:"subscriptionId,omitempty"`
+}
+
+// OneTimeProductNotification has one-time product status as notificationType, token and sku (product id)
+// to confirm status by calling Google Android Publisher API.
+type OneTimeProductNotification struct {
+	Version          string                         `json:"version"`
+	NotificationType OneTimeProductNotificationType `json:"notificationType,omitempty"`
+	PurchaseToken    string                         `json:"purchaseToken,omitempty"`
+	SKU              string                         `json:"sku,omitempty"`
+}
+
+// TestNotification is the test publish that are sent only through the Google Play Developer Console
+type TestNotification struct {
+	Version string `json:"version"`
+}


### PR DESCRIPTION
https://textnow.atlassian.net/browse/IAP-259

**Issue:**
App store notifications stopped showing up in the IAP dashboard beginning Mar 23rd.
We still receive them; we just aren't processing them.  We reject them with an HTTP 400 failing to un-marshal the notification:

https://github.com/Enflick/textnow-mono/blob/8ea951c506c95fccba88b0c5e05dc2f5f0e7d589/services/monetization/iap/appstore/notification.go#L64

Datadog shows the last time app store notification metrics were captured:  
https://app.datadoghq.com/dashboard/jtg-gts-cjq/iap?from_ts=1645365240000&to_ts=1651154040000&live=false

DD APM shows the traces: 
https://app.datadoghq.com/apm/resource/iap/opencensus/38434d72a8806b23?query=env%3Aprod%20service%3Aiap%20operation_name%3Aopencensus%20resource_name%3A%22%2Fnotification%2Fappstore%22&env=prod&topGraphs=latency%3Alatency%2Cerrors%3Aversion_count%2Chits%3Aversion_count&start=1664372441696&end=1664376041696&paused=false.

All 400 failures.

I noticed this when the /appstore/notification monitor triggered several times this week, the first time in a long time.
The monitor fires when the throughput deviates from normal. With the recent iOS IAP changes, we should see more notifications due to more subscriptions with shorter durations.
Unfortunately we didn't have any metrics around this nor any logging. I fixed that.

**Hypothesis:**
We use our own fork (copy) of go-iap: https://github.com/Enflick/go-iap.  The maintained base version is https://github.com/awa/go-iap.

An update was last made to the base appstore notification object on 3/23: https://github.com/awa/go-iap/pull/161 correcting a type in the notification.

I suspect that our problem is related to this.  My guess is we had periodic failures previous to Mar 23 but didn't notice. However since then this has been constant.

Long term we will evaluate back merging the base repo into our fork or just use the base repo