### PR TITLE
feat(appstore): upgrade refund history api to v2 and add send consumption information api

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,17 +104,30 @@ import(
     "github.com/awa/go-iap/appstore/api"
 )
 
+//  For generate key file and download it, please refer to https://developer.apple.com/documentation/appstoreserverapi/creating_api_keys_to_use_with_the_app_store_server_api
+const ACCOUNTPRIVATEKEY = `
+    -----BEGIN PRIVATE KEY-----
+    FAKEACCOUNTKEYBASE64FORMAT
+    -----END PRIVATE KEY-----
+    `
 func main() {
-    // For generate key file and download it, please refer to https://developer.apple.com/documentation/appstoreserverapi/creating_api_keys_to_use_with_the_app_store_server_api
-    token := &api.Token{
-        KeyContent : "key content",                          // Loads a .p8 certificate
-        KeyID      : "2X9R4HXF34",                           // Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
-        BundleID   : "com.example.testbundleid2021",         // Your app’s bundle ID
-        Issuer     : "57246542-96fe-1a63-e053-0824d011072a", // Your issuer ID from the Keys page in App Store Connect (Ex: "57246542-96fe-1a63-e053-0824d011072a")
-        Sandbox    : true,                                   // default is Production
+    c := &api.StoreConfig{
+        KeyContent: []byte(ACCOUNTPRIVATEKEY),  // Loads a .p8 certificate
+        KeyID:      "FAKEKEYID",                // Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
+        BundleID:   "fake.bundle.id",           // Your app’s bundle ID
+        Issuer:     "xxxxx-xx-xx-xx-xxxxxxxxxx",// Your issuer ID from the Keys page in App Store Connect (Ex: "57246542-96fe-1a63-e053-0824d011072a")
+        Sandbox:    false,                      // default is Production
     }
-    client := api.NewStoreClient(token)
-    resp, err := client.GetTransactionHistory("transactionID")
+    originalTransactionId := "FAKETRANSACTIONID"
+    a := api.NewStoreClient(c)
+    query := &url.Values{}
+    query.Set("productType", "AUTO_RENEWABLE")
+    query.Set("productType", "NON_CONSUMABLE")
+    responses, err := a.GetTransactionHistory(originalTransactionId, query)
+
+    for _, response := range responses {
+       transantions, err := a.ParseSignedTransactions(response.SignedTransactions)
+    }
 }
 ```
 

--- a/appstore/api/model.go
+++ b/appstore/api/model.go
@@ -43,6 +43,21 @@ type LastTransactionsItem struct {
 	SignedTransactionInfo string `json:"signedTransactionInfo"`
 }
 
+// ConsumptionRequestBody https://developer.apple.com/documentation/appstoreserverapi/consumptionrequest
+type ConsumptionRequestBody struct {
+	AccountTenure            int    `json:"accountTenure"`
+	AppAccountToken          string `json:"appAccountToken"`
+	ConsumptionStatus        int    `json:"consumptionStatus"`
+	CustomerConsented        bool   `json:"customerConsented"`
+	DeliveryStatus           int    `json:"deliveryStatus"`
+	LifetimeDollarsPurchased int    `json:"lifetimeDollarsPurchased"`
+	LifetimeDollarsRefunded  int    `json:"lifetimeDollarsRefunded"`
+	Platform                 int    `json:"platform"`
+	PlayTime                 int    `json:"playTime"`
+	SampleContentProvided    bool   `json:"sampleContentProvided"`
+	UserStatus               int    `json:"userStatus"`
+}
+
 type JWSRenewalInfoDecodedPayload struct {
 }
 
@@ -71,6 +86,9 @@ type JWSTransaction struct {
 	SignedDate                  int64  `json:"signedDate,omitempty"`
 	OfferType                   int64  `json:"offerType,omitempty"`
 	OfferIdentifier             string `json:"offerIdentifier,omitempty"`
+	RevocationDate              int64  `json:"revocationDate,omitempty"`
+	RevocationReason            int    `json:"revocationReason,omitempty"`
+	IsUpgraded                  bool   `json:"isUpgraded,omitempty"`
 }
 
 func (J JWSTransaction) Valid() error {

--- a/appstore/api/token.go
+++ b/appstore/api/token.go
@@ -36,6 +36,14 @@ type Token struct {
 	Bearer    string            // Authorized bearer token
 }
 
+func (t *Token) WithConfig(c *StoreConfig) {
+	t.KeyContent = append(t.KeyContent[:0:0], c.KeyContent...)
+	t.KeyID = c.KeyID
+	t.BundleID = c.BundleID
+	t.Issuer = c.Issuer
+	t.Sandbox = c.Sandbox
+}
+
 // GenerateIfExpired checks to see if the token is about to expire and generates a new token.
 func (t *Token) GenerateIfExpired() (string, error) {
 	t.Lock()


### PR DESCRIPTION
Here are several changes for AppStore server api.

1. upgrade refund history API to v2 
2. add send consumption information api
3. update readme doc for code sample