### PR TITLE
Added missing RVS Response Fields

### DIFF
--- a/amazon/validator.go
+++ b/amazon/validator.go
@@ -27,18 +27,19 @@ func getSandboxURL() string {
 
 // The IAPResponse type has the response properties
 type IAPResponse struct {
-	ReceiptID       string `json:"receiptId"`
-	ProductType     string `json:"productType"`
-	ProductID       string `json:"productId"`
-	PurchaseDate    int64  `json:"purchaseDate"`
-	RenewalDate     int64  `json:"renewalDate"`
-	CancelDate      int64  `json:"cancelDate"`
-	TestTransaction bool   `json:"testTransaction"`
-	BetaProduct     bool   `json:"betaProduct"`
-	ParentProductID string `json:"parentProductId"`
-	Quantity        int64  `json:"quantity"`
-	Term            string `json:"term"`
-	TermSku         string `json:"termSku"`
+	ReceiptID        string `json:"receiptId"`
+	ProductType      string `json:"productType"`
+	ProductID        string `json:"productId"`
+	PurchaseDate     int64  `json:"purchaseDate"`
+	RenewalDate      int64  `json:"renewalDate"`
+	CancelDate       int64  `json:"cancelDate"`
+	TestTransaction  bool   `json:"testTransaction"`
+	BetaProduct      bool   `json:"betaProduct"`
+	ParentProductID  string `json:"parentProductId"`
+	Quantity         int64  `json:"quantity"`
+	Term             string `json:"term"`
+	TermSku          string `json:"termSku"`
+	FreeTrialEndDate int64  `json:"freeTrialEndDate"`
 }
 
 // The IAPResponseError typs has error message and status.

--- a/amazon/validator_test.go
+++ b/amazon/validator_test.go
@@ -111,21 +111,22 @@ func TestVerifySubscription(t *testing.T) {
 	t.Parallel()
 	server, client := testTools(
 		200,
-		"{\"purchaseDate\":1558424877035,\"receiptId\":\"q1YqVrJSSs7P1UvMTazKz9PLTCwoTswtyEktM9JLrShIzCvOzM-LL04tiTdW0lFKASo2NDEwMjCwMDM2MTC0AIqVAsUsLd1c4l18jIxdfTOK_N1d8kqLLHVLc8oK83OLgtPNCit9AoJdjJ3dXG2BGkqUrAxrAQ\",\"productId\":\"com.amazon.iapsamplev2.expansion_set_3\",\"parentProductId\":null,\"productType\":\"SUBSCRIPTION\",\"renewalDate\":1561103277035,\"quantity\":1,\"betaProduct\":false,\"testTransaction\":true,\"term\":\"1 Week\",\"termSku\":\"sub1-weekly\"}",
+		"{\"purchaseDate\":1558424877035,\"receiptId\":\"q1YqVrJSSs7P1UvMTazKz9PLTCwoTswtyEktM9JLrShIzCvOzM-LL04tiTdW0lFKASo2NDEwMjCwMDM2MTC0AIqVAsUsLd1c4l18jIxdfTOK_N1d8kqLLHVLc8oK83OLgtPNCit9AoJdjJ3dXG2BGkqUrAxrAQ\",\"productId\":\"com.amazon.iapsamplev2.expansion_set_3\",\"parentProductId\":null,\"productType\":\"SUBSCRIPTION\",\"renewalDate\":1561103277035,\"quantity\":1,\"betaProduct\":false,\"testTransaction\":true,\"term\":\"1 Week\",\"termSku\":\"sub1-weekly\", \"freeTrialEndDate\":1561104377023}",
 	)
 	defer server.Close()
 
 	expected := IAPResponse{
-		ReceiptID:       "q1YqVrJSSs7P1UvMTazKz9PLTCwoTswtyEktM9JLrShIzCvOzM-LL04tiTdW0lFKASo2NDEwMjCwMDM2MTC0AIqVAsUsLd1c4l18jIxdfTOK_N1d8kqLLHVLc8oK83OLgtPNCit9AoJdjJ3dXG2BGkqUrAxrAQ",
-		ProductType:     "SUBSCRIPTION",
-		ProductID:       "com.amazon.iapsamplev2.expansion_set_3",
-		PurchaseDate:    1558424877035,
-		RenewalDate:     1561103277035,
-		CancelDate:      0,
-		TestTransaction: true,
-		Quantity:        1,
-		Term:            "1 Week",
-		TermSku:         "sub1-weekly",
+		ReceiptID:        "q1YqVrJSSs7P1UvMTazKz9PLTCwoTswtyEktM9JLrShIzCvOzM-LL04tiTdW0lFKASo2NDEwMjCwMDM2MTC0AIqVAsUsLd1c4l18jIxdfTOK_N1d8kqLLHVLc8oK83OLgtPNCit9AoJdjJ3dXG2BGkqUrAxrAQ",
+		ProductType:      "SUBSCRIPTION",
+		ProductID:        "com.amazon.iapsamplev2.expansion_set_3",
+		PurchaseDate:     1558424877035,
+		RenewalDate:      1561103277035,
+		CancelDate:       0,
+		TestTransaction:  true,
+		Quantity:         1,
+		Term:             "1 Week",
+		TermSku:          "sub1-weekly",
+		FreeTrialEndDate: 1561104377023,
 	}
 
 	actual, _ := client.Verify(


### PR DESCRIPTION
Added missing RVS Response Fields

[Link](https://developer.amazon.com/docs/in-app-purchasing/iap-rvs-for-android-apps.html#rvs-response-syntax) to the official documentation of amazon for RVS response fields