### PR TITLE
add PendingRenewalInfo.PromotionalOfferID

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -156,6 +156,7 @@ type (
 		ProductID                      string `json:"product_id"`
 		OriginalTransactionID          string `json:"original_transaction_id"`
 		OfferCodeRefName               string `json:"offer_code_ref_name,omitempty"`
+		PromotionalOfferID             string `json:"promotional_offer_id,omitempty"`
 
 		GracePeriodDate
 	}


### PR DESCRIPTION
According to Apple developer [docs](https://developer.apple.com/documentation/appstorereceipts/responsebody/pending_renewal_info) there is a `promotional_offer_id` field indicating the promotional offer for an auto-renewable subscription.