### PR TITLE
fix: set ExpirationIntent type of SubscriptionNotification to numericString

### DIFF
--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -101,7 +101,7 @@ type SubscriptionNotification struct {
 
 	// This is the same as the Subscription Expiration Intent in the receipt.
 	// Posted only if notification_type is RENEWAL or INTERACTIVE_RENEWAL.
-	ExpirationIntent int `json:"expiration_intent"`
+	ExpirationIntent numericString `json:"expiration_intent"`
 
 	// Auto renew info
 	AutoRenewStatus    string `json:"auto_renew_status"` // false or true


### PR DESCRIPTION
Per issue https://github.com/awa/go-iap/issues/187, change the type of ExpirationIntent type of SubscriptionNotification to numericString.