### PR TITLE
feat(ios): mark ios test receipt through ErrReceiptIsForTest

### DIFF
--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -170,7 +170,11 @@ func (c *Client) parseResponse(resp *http.Response, result interface{}, ctx cont
 			return fmt.Errorf("Received http status code %d from the App Store Sandbox: %w", resp.StatusCode, ErrAppStoreServer)
 		}
 
-		return json.NewDecoder(resp.Body).Decode(result)
+		err = json.NewDecoder(resp.Body).Decode(result)
+		if err != nil {
+			return err
+		}
+		return ErrReceiptIsForTest
 	}
 
 	return nil

--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -24,7 +24,8 @@ const (
 
 // IAPClient is an interface to call validation API in App Store
 type IAPClient interface {
-	Verify(ctx context.Context, reqBody IAPRequest, resp interface{}) (int, error)
+	Verify(ctx context.Context, reqBody IAPRequest, resp interface{}) error
+	VerifyWithStatus(ctx context.Context, reqBody IAPRequest, resp interface{}) (int, error)
 }
 
 // Client implements IAPClient
@@ -108,7 +109,17 @@ func NewWithClient(client *http.Client) *Client {
 }
 
 // Verify sends receipts and gets validation result
-func (c *Client) Verify(ctx context.Context, reqBody IAPRequest, result interface{}) (int, error) {
+func (c *Client) Verify(ctx context.Context, reqBody IAPRequest, result interface{}) error {
+	_, err := c.verify(ctx, reqBody, result)
+	return err
+}
+
+// VerifyWithStatus sends receipts and gets validation result with status code
+func (c *Client) VerifyWithStatus(ctx context.Context, reqBody IAPRequest, result interface{}) (int, error) {
+	return c.verify(ctx, reqBody, result)
+}
+
+func (c *Client) verify(ctx context.Context, reqBody IAPRequest, result interface{}) (int, error) {
 	b := new(bytes.Buffer)
 	if err := json.NewEncoder(b).Encode(reqBody); err != nil {
 		return 0, err

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -286,7 +286,7 @@ func TestCannotReadBody(t *testing.T) {
 	testResponse := http.Response{Body: ioutil.NopCloser(errReader(0))}
 
 	ctx := context.Background()
-	if client.parseResponse(&testResponse, IAPResponse{}, ctx, IAPRequest{}) == nil {
+	if _, err := client.parseResponse(&testResponse, IAPResponse{}, ctx, IAPRequest{}); err == nil {
 		t.Errorf("expected redirectToSandbox to fail to read the body")
 	}
 }
@@ -296,7 +296,7 @@ func TestCannotUnmarshalBody(t *testing.T) {
 	testResponse := http.Response{Body: ioutil.NopCloser(strings.NewReader(`{"status": true}`))}
 
 	ctx := context.Background()
-	if client.parseResponse(&testResponse, StatusResponse{}, ctx, IAPRequest{}) == nil {
+	if _, err := client.parseResponse(&testResponse, StatusResponse{}, ctx, IAPRequest{}); err == nil {
 		t.Errorf("expected redirectToSandbox to fail to unmarshal the data")
 	}
 }


### PR DESCRIPTION
Currently, in order to distinguish test receipts in iOS, there is one field Environment in iOS7 and higher. However, there is no explicit field to mark whether the receipt is a test or not for the iOS6 receipt. 

Originally, the field AppItemID was to be used to mark whether the receipt is test receipt or not for the iOS6 receipt. Unfortunately, this field was set in test receipt recently. It seems there is no explicit field to distinguish whether the receipt is test receipt or not. I post this PR to return the ErrReceiptIsForTest when the status is 21007, we could check if the receipt is test receipt through this error. 

Maybe there could be a more elegant way to solve it?