### PR TITLE
feat(appstore): return detailed error information out to caller

### DIFF
--- a/appstore/api/error.go
+++ b/appstore/api/error.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Error struct {
+	// Only errorCode and errorMessage are returned by App Store Server API.
+	errorCode    int
+	errorMessage string
+}
+
+func newError(errorCode int, errorMessage string) *Error {
+	return &Error{
+		errorCode:    errorCode,
+		errorMessage: errorMessage,
+	}
+}
+
+type appStoreAPIErrorResp struct {
+	ErrorCode    int    `json:"errorCode"`
+	ErrorMessage string `json:"errorMessage"`
+}
+
+func newErrorFromJSON(b []byte) (*Error, bool) {
+	if len(b) == 0 {
+		return nil, false
+	}
+	var rErr appStoreAPIErrorResp
+	if err := json.Unmarshal(b, &rErr); err != nil {
+		return nil, false
+	}
+	if rErr.ErrorCode == 0 {
+		return nil, false
+	}
+	return &Error{errorCode: rErr.ErrorCode, errorMessage: rErr.ErrorMessage}, true
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("errorCode: %d, errorMessage: %s", e.errorCode, e.errorMessage)
+}
+
+func (e *Error) As(target interface{}) bool {
+	if targetErr, ok := target.(*Error); ok {
+		*targetErr = *e
+		return true
+	}
+	return false
+}
+
+func (e *Error) Is(target error) bool {
+	if other, ok := target.(*Error); ok && other.errorCode == e.errorCode {
+		return true
+	}
+	return false
+}
+
+func (e *Error) ErrorCode() int {
+	return e.errorCode
+}
+
+func (e *Error) ErrorMessage() string {
+	return e.errorMessage
+}
+
+func (e *Error) Retryable() bool {
+	// NOTE:
+	// RateLimitExceededError[1] could also be considered as a retryable error.
+	// But limits are enforced on an hourly basis[2], so you should handle exceeded rate limits gracefully instead of retrying immediately.
+	// Refs:
+	// [1] https://developer.apple.com/documentation/appstoreserverapi/ratelimitexceedederror
+	// [2] https://developer.apple.com/documentation/appstoreserverapi/identifying_rate_limits
+	switch e.errorCode {
+	case 4040002, 4040004, 5000001, 4040006:
+		return true
+	default:
+		return false
+	}
+}
+
+// All Error lists in https://developer.apple.com/documentation/appstoreserverapi/error_codes.
+var (
+	// Retryable errors
+	AccountNotFoundRetryableError               = newError(4040002, "Account not found. Please try again.")
+	AppNotFoundRetryableError                   = newError(4040004, "App not found. Please try again.")
+	GeneralInternalRetryableError               = newError(5000001, "An unknown error occurred. Please try again.")
+	OriginalTransactionIdNotFoundRetryableError = newError(4040006, "Original transaction id not found. Please try again.")
+	// Errors
+	AccountNotFoundError                             = newError(4040001, "Account not found.")
+	AppNotFoundError                                 = newError(4040003, "App not found.")
+	FamilySharedSubscriptionExtensionIneligibleError = newError(4030007, "Subscriptions that users obtain through Family Sharing can't get a renewal date extension directly.")
+	GeneralInternalError                             = newError(5000000, "An unknown error occurred.")
+	GeneralBadRequestError                           = newError(4000000, "Bad request.")
+	InvalidAppIdentifierError                        = newError(4000002, "Invalid request app identifier.")
+	InvalidEmptyStorefrontCountryCodeListError       = newError(4000027, "Invalid request. If provided, the list of storefront country codes must not be empty.")
+	InvalidExtendByDaysError                         = newError(4000009, "Invalid extend by days value.")
+	InvalidExtendReasonCodeError                     = newError(4000010, "Invalid extend reason code.")
+	InvalidOriginalTransactionIdError                = newError(4000008, "Invalid original transaction id.")
+	InvalidRequestIdentifierError                    = newError(4000011, "Invalid request identifier.")
+	InvalidRequestRevisionError                      = newError(4000005, "Invalid request revision.")
+	InvalidRevokedError                              = newError(4000030, "Invalid request. The revoked parameter is invalid.")
+	InvalidStatusError                               = newError(4000031, "Invalid request. The status parameter is invalid.")
+	InvalidStorefrontCountryCodeError                = newError(4000028, "Invalid request. A storefront country code was invalid.")
+	InvalidTransactionIdError                        = newError(4000006, "Invalid transaction id.")
+	OriginalTransactionIdNotFoundError               = newError(4040005, "Original transaction id not found.")
+	RateLimitExceededError                           = newError(4290000, "Rate limit exceeded.")
+	StatusRequestNotFoundError                       = newError(4040009, "The server didn't find a subscription-renewal-date extension request for this requestIdentifier and productId combination.")
+	SubscriptionExtensionIneligibleError             = newError(4030004, "Forbidden - subscription state ineligible for extension.")
+	SubscriptionMaxExtensionError                    = newError(4030005, "Forbidden - subscription has reached maximum extension count.")
+	TransactionIdNotFoundError                       = newError(4040010, "Transaction id not found.")
+	// Notification test and history errors
+	InvalidEndDateError                     = newError(4000016, "Invalid request. The end date is not a timestamp value represented in milliseconds.")
+	InvalidNotificationTypeError            = newError(4000018, "Invalid request. The notification type or subtype is invalid.")
+	InvalidPaginationTokenError             = newError(4000014, "Invalid request. The pagination token is invalid.")
+	InvalidStartDateError                   = newError(4000015, "Invalid request. The start date is not a timestamp value represented in milliseconds.")
+	InvalidTestNotificationTokenError       = newError(4000020, "Invalid request. The test notification token is invalid.")
+	InvalidInAppOwnershipTypeError          = newError(4000026, "Invalid request. The in-app ownership type parameter is invalid.")
+	InvalidProductIdError                   = newError(4000023, "Invalid request. The product id parameter is invalid.")
+	InvalidProductTypeError                 = newError(4000022, "Invalid request. The product type parameter is invalid.")
+	InvalidSortError                        = newError(4000021, "Invalid request. The sort parameter is invalid.")
+	InvalidSubscriptionGroupIdentifierError = newError(4000024, "Invalid request. The subscription group identifier parameter is invalid.")
+	MultipleFiltersSuppliedError            = newError(4000019, "Invalid request. Supply either a transaction id or a notification type, but not both.")
+	PaginationTokenExpiredError             = newError(4000017, "Invalid request. The pagination token is expired.")
+	ServerNotificationURLNotFoundError      = newError(4040007, "No App Store Server Notification URL found for provided app. Check that a URL is configured in App Store Connect for this environment.")
+	StartDateAfterEndDateError              = newError(4000013, "Invalid request. The end date precedes the start date or the dates are the same.")
+	StartDateTooFarInPastError              = newError(4000012, "Invalid request. The start date is earlier than the allowed start date.")
+	TestNotificationNotFoundError           = newError(4040008, "Either the test notification token is expired or the notification and status are not yet available.")
+)

--- a/appstore/api/error_test.go
+++ b/appstore/api/error_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError_As(t *testing.T) {
+	tests := []struct {
+		SrcError   error
+		ExpectedAs bool // Check If SrcError can be 'As' to Error.
+	}{
+		{SrcError: AccountNotFoundError, ExpectedAs: true},
+		{SrcError: AppNotFoundError, ExpectedAs: true},
+		{SrcError: fmt.Errorf("custom error"), ExpectedAs: false},
+		{SrcError: fmt.Errorf("wrapping: %w", AccountNotFoundError), ExpectedAs: true},
+		{SrcError: errors.Unwrap(fmt.Errorf("wrapping: %w", AccountNotFoundError)), ExpectedAs: true},
+	}
+
+	for _, test := range tests {
+		var apiErr *Error
+		as := errors.As(test.SrcError, &apiErr)
+		assert.Equal(t, test.ExpectedAs, as)
+		if test.ExpectedAs {
+			assert.NotZero(t, apiErr.errorCode)
+			assert.NotZero(t, apiErr.errorMessage)
+		} else {
+			assert.Nil(t, apiErr)
+		}
+	}
+
+}
+
+func TestError_Is(t *testing.T) {
+	tests := []struct {
+		ErrBytes    []byte
+		TargetError error
+		ExpectedIs  bool // Check if error (constructed by ErrBytes) Is TargetError Or not.
+	}{
+		{ErrBytes: []byte(`{"errorCode": 4040001, "errorMessage": "Account not found."}`), TargetError: AccountNotFoundError, ExpectedIs: true},
+		{ErrBytes: []byte(`{"errorCode": 4040001, "errorMessage": "Account not found."}`), TargetError: AppNotFoundError, ExpectedIs: false},
+		{ErrBytes: []byte(`{"errorCode": 4040001, "errorMessage": "Account not found."}`), TargetError: fmt.Errorf("custom error"), ExpectedIs: false},
+		{ErrBytes: []byte(`{"errorCode": 4040001, "errorMessage": "Account not found."}`), TargetError: fmt.Errorf("wrapping: %w", AccountNotFoundError), ExpectedIs: false},
+		{ErrBytes: []byte(`{"errorCode": 4040001, "errorMessage": "Account not found."}`), TargetError: errors.Unwrap(fmt.Errorf("wrapping: %w", AccountNotFoundError)), ExpectedIs: true},
+	}
+	for _, test := range tests {
+		err, ok := newErrorFromJSON(test.ErrBytes)
+		assert.True(t, ok)
+		assert.Equal(t, test.ExpectedIs, errors.Is(err, test.TargetError))
+	}
+}
+
+func TestError_Is2(t *testing.T) {
+	tests := []struct {
+		SrcError    error
+		TargetError error
+		ExpectedIs  bool // Check if SrcError is TargetError or not.
+	}{
+		{SrcError: AccountNotFoundError, TargetError: AccountNotFoundError, ExpectedIs: true},
+		{SrcError: AppNotFoundError, TargetError: AccountNotFoundError, ExpectedIs: false},
+		{SrcError: fmt.Errorf("custom error"), TargetError: AccountNotFoundError, ExpectedIs: false},
+		{SrcError: fmt.Errorf("wrapping: %w", AccountNotFoundError), TargetError: AccountNotFoundError, ExpectedIs: true},
+		{SrcError: errors.Unwrap(fmt.Errorf("wrapping: %w", AccountNotFoundError)), TargetError: AccountNotFoundError, ExpectedIs: true},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.ExpectedIs, errors.Is(test.SrcError, test.TargetError))
+	}
+}

--- a/appstore/api/store.go
+++ b/appstore/api/store.go
@@ -472,5 +472,12 @@ func (a *StoreClient) Do(ctx context.Context, method string, url string, body io
 		return resp.StatusCode, nil, fmt.Errorf("appstore read http body err %w", err)
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		// try to extract detailed error.
+		if rErr, ok := newErrorFromJSON(bytes); ok {
+			return resp.StatusCode, bytes, rErr
+		}
+	}
+
 	return resp.StatusCode, bytes, err
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.3.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
+	github.com/stretchr/testify v1.8.1
 	golang.org/x/oauth2 v0.7.0
 	google.golang.org/api v0.118.0
 	google.golang.org/appengine v1.6.7
@@ -14,11 +15,13 @@ require (
 require (
 	cloud.google.com/go/compute v1.19.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/s2a-go v0.1.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.8.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
@@ -27,4 +30,5 @@ require (
 	google.golang.org/genproto v0.0.0-20230403163135-c38d8f061ccd // indirect
 	google.golang.org/grpc v1.54.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -69,6 +70,7 @@ github.com/googleapis/enterprise-certificate-proxy v0.2.3/go.mod h1:AwSRAtLfXpU5
 github.com/googleapis/gax-go/v2 v2.8.0 h1:UBtEZqx1bjXtOQ5BVTkuYghXrr3N4V123VKJK67vJZc=
 github.com/googleapis/gax-go/v2 v2.8.0/go.mod h1:4orTrqY6hXxxaUL4LHIPl6lGo8vAE38/qKbhSAKP6QI=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -79,6 +81,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
@@ -187,10 +190,12 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
The original implementation of returning `fmt.Errorf("appstore api: %v return status code %v", URL, statusCode)` provides too little information for developers to figure out what's happening.
The PR will bring these changes:
1. When calling `StoreClient.Do`, i only return the custom `Error` when status code is not 'OK' and the unmarshal is successful. So this will not change the behaviour that the callers to StoreClient.Do (`GetALLSubscriptionStatuses` etc.) still return error to further caller when status code is not 'OK'.
2. But maybe some developers using this library like regex matching the error message `appstore api: %v return status code %v", URL, statusCode` to get status code (no a good usage). So this is a breaking change for theses developers.