### PR TITLE
feat(appstore): add RetryAfter method to Error

### DIFF
--- a/appstore/api/error.go
+++ b/appstore/api/error.go
@@ -90,6 +90,10 @@ func (e *Error) ErrorMessage() string {
 	return e.errorMessage
 }
 
+func (e *Error) RetryAfter() int64 {
+	return e.retryAfter
+}
+
 func (e *Error) Retryable() bool {
 	// NOTE:
 	// RateLimitExceededError[1] could also be considered as a retryable error.


### PR DESCRIPTION
- https://github.com/awa/go-iap/pull/217#issuecomment-1612462192

feat(appstore): add RetryAfter method to Error to expose the `retryAfter`