### PR TITLE
fix and refactor appstore get_notification_history

### DIFF
--- a/appstore/api/model.go
+++ b/appstore/api/model.go
@@ -185,13 +185,15 @@ type MassExtendRenewalDateStatusResponse struct {
 
 // NotificationHistoryRequest https://developer.apple.com/documentation/appstoreserverapi/notificationhistoryrequest
 type NotificationHistoryRequest struct {
-	StartDate             int64                       `json:"startDate"`
-	EndDate               int64                       `json:"endDate"`
-	OriginalTransactionId string                      `json:"originalTransactionId,omitempty"`
-	NotificationType      appstore.NotificationTypeV2 `json:"notificationType,omitempty"`
-	NotificationSubtype   appstore.SubtypeV2          `json:"notificationSubtype,omitempty"`
-	OnlyFailures          bool                        `json:"onlyFailures"`
-	TransactionId         string                      `json:"transactionId"`
+	StartDate           int64                       `json:"startDate"`
+	EndDate             int64                       `json:"endDate"`
+	NotificationType    appstore.NotificationTypeV2 `json:"notificationType,omitempty"`
+	NotificationSubtype appstore.SubtypeV2          `json:"notificationSubtype,omitempty"`
+	OnlyFailures        bool                        `json:"onlyFailures"`
+	TransactionId       string                      `json:"transactionId,omitempty"`
+	// Use transactionId instead.
+	// Deprecated.
+	OriginalTransactionId string `json:"originalTransactionId,omitempty"`
 }
 
 // NotificationHistoryResponses https://developer.apple.com/documentation/appstoreserverapi/notificationhistoryresponse

--- a/appstore/api/store.go
+++ b/appstore/api/store.go
@@ -310,6 +310,10 @@ func (a *StoreClient) GetSubscriptionRenewalDataStatus(ctx context.Context, prod
 	URL = strings.Replace(URL, "{requestIdentifier}", requestIdentifier, -1)
 
 	statusCode, body, err := a.Do(ctx, http.MethodGet, URL, nil)
+	if err != nil {
+		return statusCode, nil, err
+	}
+
 	if statusCode != http.StatusOK {
 		return statusCode, nil, fmt.Errorf("appstore api: %v return status code %v", URL, statusCode)
 	}


### PR DESCRIPTION
This PR brings following updates:
1. Fix the json tag of NotificationHistoryRequest.TransactionId, which should be omitempty. Otherwise the App Store Server API will return invalidTransactionId Error.
2. Breaking changes: Implement a single page version of get_notification_history and `GetAllNotificationHistory` will use it directly.
3. Per PR(https://github.com/awa/go-iap/pull/208), return detailed error first in `GetSubscriptionRenewalDataStatus`.

Btw, ff the 2nd update is approved, we may consider replace all the current implementation of history-like method, `GetTransactionHistory` etc.