### PR TITLE
feat(appstore): add ParseJWSEncodeString to decode jws string

### DIFF
--- a/appstore/api/model.go
+++ b/appstore/api/model.go
@@ -100,6 +100,10 @@ type JWSRenewalInfoDecodedPayload struct {
 	SignedDate                  int64       `json:"signedDate"`
 }
 
+func (J JWSRenewalInfoDecodedPayload) Valid() error {
+	return nil
+}
+
 // JWSDecodedHeader https://developer.apple.com/documentation/appstoreserverapi/jwsdecodedheader
 type JWSDecodedHeader struct {
 	Alg string   `json:"alg,omitempty"`


### PR DESCRIPTION
Add  ParseJWSEncodeString to decode jws string, such as JWSTransaction and JWSRenewalInfoDecodedPayload decode.

Related issue: https://github.com/awa/go-iap/issues/227