### PR TITLE
Correct typo in const for test notification type

### DIFF
--- a/appstore/notification_v2.go
+++ b/appstore/notification_v2.go
@@ -22,7 +22,7 @@ const (
 	NotificationTypeV2RenewalExtension       NotificationTypeV2 = "RENEWAL_EXTENSION"
 	NotificationTypeV2Revoke                 NotificationTypeV2 = "REVOKE"
 	NotificationTypeV2Subscribed             NotificationTypeV2 = "SUBSCRIBED"
-	NotificationTyp2V2Test                   NotificationTypeV2 = "TEST"
+	NotificationTypeV2Test                   NotificationTypeV2 = "TEST"
 )
 
 // SubtypeV2 is type


### PR DESCRIPTION
`NotificationTyp2V2Test` corrected to `NotificationTypeV2Test`