### PR TITLE
fix(googleplay): fix type for eventTimeMillis

### DIFF
--- a/playstore/notification.go
+++ b/playstore/notification.go
@@ -33,7 +33,7 @@ const (
 type DeveloperNotification struct {
 	Version                    string                     `json:"version"`
 	PackageName                string                     `json:"packageName"`
-	EventTimeMillis            string                     `json:"eventTimeMillis"`
+	EventTimeMillis            int64                      `json:"eventTimeMillis"`
 	SubscriptionNotification   SubscriptionNotification   `json:"subscriptionNotification,omitempty"`
 	OneTimeProductNotification OneTimeProductNotification `json:"oneTimeProductNotification,omitempty"`
 	TestNotification           TestNotification           `json:"testNotification,omitempty"`


### PR DESCRIPTION
- https://developer.android.com/google/play/billing/rtdn-reference?hl=en#json_specification
- `eventTimeMillis` is long, but defined as string
- possible error when marshaling from JSON to struct