### PR TITLE
feat(appstore): add more fields to JWSTransaction

### DIFF
--- a/appstore/api/model.go
+++ b/appstore/api/model.go
@@ -130,6 +130,14 @@ const (
 	NonRenewable  IAPType = "Non-Renewing Subscription"
 )
 
+type OfferDiscountType string
+
+const (
+	OfferDiscountTypeFreeTrial  OfferDiscountType = "FREE_TRIAL"
+	OfferDiscountTypePayAsYouGo OfferDiscountType = "PAY_AS_YOU_GO"
+	OfferDiscountTypePayUpFront OfferDiscountType = "PAY_UP_FRONT"
+)
+
 // JWSTransaction https://developer.apple.com/documentation/appstoreserverapi/jwstransaction
 type JWSTransaction struct {
 	TransactionID               string            `json:"transactionId,omitempty"`
@@ -155,6 +163,9 @@ type JWSTransaction struct {
 	StorefrontId                string            `json:"storefrontId,omitempty"`
 	TransactionReason           TransactionReason `json:"transactionReason,omitempty"`
 	Environment                 Environment       `json:"environment,omitempty"`
+	Price                       int32             `json:"price,omitempty"`
+	Currency                    string            `json:"currency,omitempty"`
+	OfferDiscountType           OfferDiscountType `json:"offerDiscountType,omitempty"`
 }
 
 func (J JWSTransaction) Valid() error {


### PR DESCRIPTION
Per doc https://developer.apple.com/documentation/appstoreserverapi/jwstransactiondecodedpayload?changes=latest_minor, the `price`, `concurrency` and OfferDiscountType are added into JWSTransction in the latest version.

https://github.com/awa/go-iap/issues/250