### PR TITLE
feat(playstore): add VoidedPurchaseNotification in playstore notification

### DIFF
--- a/playstore/notification.go
+++ b/playstore/notification.go
@@ -39,13 +39,13 @@ const (
 // Detailed description is following.
 // https://developer.android.com/google/play/billing/rtdn-reference#json_specification
 type DeveloperNotification struct {
-	Version                    string                      `json:"version"`
-	PackageName                string                      `json:"packageName"`
-	EventTimeMillis            string                      `json:"eventTimeMillis"`
-	SubscriptionNotification   SubscriptionNotification    `json:"subscriptionNotification,omitempty"`
-	OneTimeProductNotification OneTimeProductNotification  `json:"oneTimeProductNotification,omitempty"`
-	VoidedPurchaseNotification *VoidedPurchaseNotification `json:"voidedPurchaseNotification,omitempty"`
-	TestNotification           TestNotification            `json:"testNotification,omitempty"`
+	Version                    string                     `json:"version"`
+	PackageName                string                     `json:"packageName"`
+	EventTimeMillis            string                     `json:"eventTimeMillis"`
+	SubscriptionNotification   SubscriptionNotification   `json:"subscriptionNotification,omitempty"`
+	OneTimeProductNotification OneTimeProductNotification `json:"oneTimeProductNotification,omitempty"`
+	VoidedPurchaseNotification VoidedPurchaseNotification `json:"voidedPurchaseNotification,omitempty"`
+	TestNotification           TestNotification           `json:"testNotification,omitempty"`
 }
 
 // SubscriptionNotification has subscription status as notificationType, token and subscription id

--- a/playstore/notification.go
+++ b/playstore/notification.go
@@ -27,16 +27,25 @@ const (
 	OneTimeProductNotificationTypeCanceled
 )
 
+// https://developer.android.com/google/play/billing/rtdn-reference#voided-purchase
+type VoidedPurchaseProductType int
+
+const (
+	VoidedPurchaseProductTypeSubscription = iota + 1
+	VoidedPurchaseProductTypeOneTime
+)
+
 // DeveloperNotification is sent by a Pub/Sub topic.
 // Detailed description is following.
 // https://developer.android.com/google/play/billing/rtdn-reference#json_specification
 type DeveloperNotification struct {
-	Version                    string                     `json:"version"`
-	PackageName                string                     `json:"packageName"`
-	EventTimeMillis            string                     `json:"eventTimeMillis"`
-	SubscriptionNotification   SubscriptionNotification   `json:"subscriptionNotification,omitempty"`
-	OneTimeProductNotification OneTimeProductNotification `json:"oneTimeProductNotification,omitempty"`
-	TestNotification           TestNotification           `json:"testNotification,omitempty"`
+	Version                    string                      `json:"version"`
+	PackageName                string                      `json:"packageName"`
+	EventTimeMillis            string                      `json:"eventTimeMillis"`
+	SubscriptionNotification   SubscriptionNotification    `json:"subscriptionNotification,omitempty"`
+	OneTimeProductNotification OneTimeProductNotification  `json:"oneTimeProductNotification,omitempty"`
+	VoidedPurchaseNotification *VoidedPurchaseNotification `json:"voidedPurchaseNotification,omitempty"`
+	TestNotification           TestNotification            `json:"testNotification,omitempty"`
 }
 
 // SubscriptionNotification has subscription status as notificationType, token and subscription id
@@ -55,6 +64,15 @@ type OneTimeProductNotification struct {
 	NotificationType OneTimeProductNotificationType `json:"notificationType,omitempty"`
 	PurchaseToken    string                         `json:"purchaseToken,omitempty"`
 	SKU              string                         `json:"sku,omitempty"`
+}
+
+// VoidedPurchaseNotification has token, order and product type to locate the right purchase and order.
+// To learn how to get additional information about the voided purchase, check out the Google Play Voided Purchases API,
+// which is a pull model that provides additional data for voided purchases between a given timestamp.
+type VoidedPurchaseNotification struct {
+	PurchaseToken string                    `json:"purchaseToken"`
+	OrderID       string                    `json:"orderId"`
+	ProductType   VoidedPurchaseProductType `json:"productType"`
 }
 
 // TestNotification is the test publish that are sent only through the Google Play Developer Console

--- a/playstore/validator_test.go
+++ b/playstore/validator_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"google.golang.org/api/androidpublisher/v3"
 	"google.golang.org/appengine/urlfetch"
@@ -195,11 +196,15 @@ func TestConsumeProduct(t *testing.T) {
 func TestVoidedPurchases(t *testing.T) {
 	t.Parallel()
 	// Exception scenario
-	expected := "googleapi: Error 403: The current user has insufficient permissions to perform the requested operation., forbidden"
+	expected := "googleapi: Error 404: No application was found for the given package name., applicationNotFound"
 
 	client, _ := New(jsonKey)
 	ctx := context.Background()
-	_, err := client.VoidedPurchases(ctx, "package", 0, 0, 3, "token", 0, VoidedPurchaseTypeWithoutSubscription)
+
+	endTime := time.Now()
+	startTime := endTime.Add(-29 * 24 * time.Hour)
+
+	_, err := client.VoidedPurchases(ctx, "package", startTime.UnixMilli(), endTime.UnixMilli(), 3, "", 0, VoidedPurchaseTypeWithoutSubscription)
 
 	if err == nil || err.Error() != expected {
 		t.Errorf("got %v", err)


### PR DESCRIPTION
Add new notification type (`VoidedPurchaseNotification`) in playstore per doc: https://developer.android.com/google/play/billing/rtdn-reference#voided-purchase
Use `*VoidedPurchaseNotification` instead of `VoidedPurchaseNotification` as there is no `version` field inside `VoidedPurchaseNotification` like other notification types for developer to gracefully check if this specific type of notification is present.