### PR TITLE
fix(appstore): possible nil pointer access in ParseNotificationV2

### DIFF
--- a/appstore/validator.go
+++ b/appstore/validator.go
@@ -199,7 +199,9 @@ func (c *Client) ParseNotificationV2(tokenStr string, result *jwt.Token) error {
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
 		return cert.ExtractPublicKeyFromToken(tokenStr)
 	})
-	*result = *token
+	if token != nil {
+		*result = *token
+	}
 	return err
 }
 


### PR DESCRIPTION
Fixed possible nil pointer access in `(*appstore.Client).ParseNotificationV2` on token parse error.