### PR TITLE
Multiple fixes around NumericString type

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -105,7 +105,7 @@ type (
 		Quantity                    string        `json:"quantity"`
 		ProductID                   string        `json:"product_id"`
 		TransactionID               string        `json:"transaction_id"`
-		OriginalTransactionID       NumericString `json:"original_transaction_id"`
+		OriginalTransactionID       NumericString `json:"original_transaction_id,omitempty"`
 		WebOrderLineItemID          string        `json:"web_order_line_item_id,omitempty"`
 		PromotionalOfferID          string        `json:"promotional_offer_id"`
 		SubscriptionGroupIdentifier string        `json:"subscription_group_identifier"`
@@ -211,7 +211,7 @@ type (
 		ItemID               string `json:"item_id"`
 		ProductID            string `json:"product_id"`
 		PurchaseDate
-		OriginalTransactionID NumericString `json:"original_transaction_id"`
+		OriginalTransactionID NumericString `json:"original_transaction_id,omitempty"`
 		OriginalPurchaseDate
 		Quantity                  string        `json:"quantity"`
 		TransactionID             string        `json:"transaction_id"`

--- a/appstore/model.go
+++ b/appstore/model.go
@@ -102,15 +102,15 @@ type (
 
 	// The InApp type has the receipt attributes
 	InApp struct {
-		Quantity                    string `json:"quantity"`
-		ProductID                   string `json:"product_id"`
-		TransactionID               string `json:"transaction_id"`
-		OriginalTransactionID       string `json:"original_transaction_id"` // this field is string
-		WebOrderLineItemID          string `json:"web_order_line_item_id,omitempty"`
-		PromotionalOfferID          string `json:"promotional_offer_id"`
-		SubscriptionGroupIdentifier string `json:"subscription_group_identifier"`
-		OfferCodeRefName            string `json:"offer_code_ref_name,omitempty"`
-		AppAccountToken             string `json:"app_account_token,omitempty"`
+		Quantity                    string        `json:"quantity"`
+		ProductID                   string        `json:"product_id"`
+		TransactionID               string        `json:"transaction_id"`
+		OriginalTransactionID       NumericString `json:"original_transaction_id"`
+		WebOrderLineItemID          string        `json:"web_order_line_item_id,omitempty"`
+		PromotionalOfferID          string        `json:"promotional_offer_id"`
+		SubscriptionGroupIdentifier string        `json:"subscription_group_identifier"`
+		OfferCodeRefName            string        `json:"offer_code_ref_name,omitempty"`
+		AppAccountToken             string        `json:"app_account_token,omitempty"`
 
 		IsTrialPeriod        string `json:"is_trial_period"`
 		IsInIntroOfferPeriod string `json:"is_in_intro_offer_period,omitempty"`

--- a/appstore/model.go
+++ b/appstore/model.go
@@ -2,14 +2,14 @@ package appstore
 
 import "encoding/json"
 
-type numericString string
+type NumericString string
 
-func (n *numericString) UnmarshalJSON(b []byte) error {
+func (n *NumericString) UnmarshalJSON(b []byte) error {
 	var number json.Number
 	if err := json.Unmarshal(b, &number); err != nil {
 		return err
 	}
-	*n = numericString(number.String())
+	*n = NumericString(number.String())
 	return nil
 }
 
@@ -131,11 +131,11 @@ type (
 	Receipt struct {
 		ReceiptType                string        `json:"receipt_type"`
 		AdamID                     int64         `json:"adam_id"`
-		AppItemID                  numericString `json:"app_item_id"`
+		AppItemID                  NumericString `json:"app_item_id"`
 		BundleID                   string        `json:"bundle_id"`
 		ApplicationVersion         string        `json:"application_version"`
 		DownloadID                 int64         `json:"download_id"`
-		VersionExternalIdentifier  numericString `json:"version_external_identifier"`
+		VersionExternalIdentifier  NumericString `json:"version_external_identifier"`
 		OriginalApplicationVersion string        `json:"original_application_version"`
 		InApp                      []InApp       `json:"in_app"`
 		ReceiptCreationDate
@@ -201,7 +201,7 @@ type (
 
 	// ReceiptForIOS6 is struct
 	ReceiptForIOS6 struct {
-		AppItemID numericString `json:"app_item_id"`
+		AppItemID NumericString `json:"app_item_id"`
 		BID       string        `json:"bid"`
 		BVRS      string        `json:"bvrs"`
 		CancellationDate
@@ -211,13 +211,13 @@ type (
 		ItemID               string `json:"item_id"`
 		ProductID            string `json:"product_id"`
 		PurchaseDate
-		OriginalTransactionID numericString `json:"original_transaction_id"`
+		OriginalTransactionID NumericString `json:"original_transaction_id"`
 		OriginalPurchaseDate
 		Quantity                  string        `json:"quantity"`
 		TransactionID             string        `json:"transaction_id"`
 		UniqueIdentifier          string        `json:"unique_identifier"`
 		UniqueVendorIdentifier    string        `json:"unique_vendor_identifier"`
-		VersionExternalIdentifier numericString `json:"version_external_identifier,omitempty"`
+		VersionExternalIdentifier NumericString `json:"version_external_identifier,omitempty"`
 		WebOrderLineItemID        string        `json:"web_order_line_item_id"`
 	}
 )

--- a/appstore/model_test.go
+++ b/appstore/model_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNumericString_UnmarshalJSON(t *testing.T) {
 	type foo struct {
-		ID numericString
+		ID NumericString
 	}
 
 	tests := []struct {

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -66,7 +66,7 @@ type NotificationReceipt struct {
 	BID                       string        `json:"bid"`
 	BVRS                      string        `json:"bvrs"`
 	TransactionID             string        `json:"transaction_id"`
-	OriginalTransactionID     NumericString `json:"original_transaction_id"`
+	OriginalTransactionID     NumericString `json:"original_transaction_id,omitempty"`
 	IsTrialPeriod             string        `json:"is_trial_period"`
 	IsInIntroOfferPeriod      string        `json:"is_in_intro_offer_period"`
 
@@ -94,7 +94,7 @@ type SubscriptionNotification struct {
 
 	// Not show in raw notify body
 	Password              string        `json:"password"`
-	OriginalTransactionID NumericString `json:"original_transaction_id"`
+	OriginalTransactionID NumericString `json:"original_transaction_id,omitempty"`
 	AutoRenewAdamID       string        `json:"auto_renew_adam_id"`
 
 	// The primary key for identifying a subscription purchase.

--- a/appstore/notification.go
+++ b/appstore/notification.go
@@ -66,7 +66,7 @@ type NotificationReceipt struct {
 	BID                       string        `json:"bid"`
 	BVRS                      string        `json:"bvrs"`
 	TransactionID             string        `json:"transaction_id"`
-	OriginalTransactionID     numericString `json:"original_transaction_id"`
+	OriginalTransactionID     NumericString `json:"original_transaction_id"`
 	IsTrialPeriod             string        `json:"is_trial_period"`
 	IsInIntroOfferPeriod      string        `json:"is_in_intro_offer_period"`
 
@@ -94,7 +94,7 @@ type SubscriptionNotification struct {
 
 	// Not show in raw notify body
 	Password              string        `json:"password"`
-	OriginalTransactionID numericString `json:"original_transaction_id"`
+	OriginalTransactionID NumericString `json:"original_transaction_id"`
 	AutoRenewAdamID       string        `json:"auto_renew_adam_id"`
 
 	// The primary key for identifying a subscription purchase.
@@ -103,7 +103,7 @@ type SubscriptionNotification struct {
 
 	// This is the same as the Subscription Expiration Intent in the receipt.
 	// Posted only if notification_type is RENEWAL or INTERACTIVE_RENEWAL.
-	ExpirationIntent numericString `json:"expiration_intent"`
+	ExpirationIntent NumericString `json:"expiration_intent"`
 
 	// Auto renew info
 	AutoRenewStatus    string `json:"auto_renew_status"` // false or true


### PR DESCRIPTION
Hi AWA team !

Here at TextNow we use your repository in order to communicate with Apple and Google for our IAP.

While using this repository, we found some potentialk improvements regarding the use of `NumericString` type.

We are using these fixes for a while in our Production environment and have no problem so far.

Changes:
- Rename `numericString` to `NumericString` : This is usually a good pattern that every field of a public struct are made of purely public types. With this, we can easily build structs containing `NumericString` type in order to run tests and compare results.
- Modify `InApp.OriginalTransactionID` from `string` to `NumericString` : similarly to `ReceiptForIOS6.OriginalTransactionID`, this field is also worth using  `NumericString`. This also simplifies comparing the 2 fields since they would be the same type.
- Adds `omitempty` to some `NumericString` fields : Apple usually do not send empty `OriginalTransactionID` and the `NumericString` type fails to parse empty strings. If we Marshall->Unmarshall a struct with `NumericString` in it, it fails since we produce an empty string when Marshalling. An alternative would be to not fail when parsing an empty string, but I'm not sure this is a wanted change but feel free to ask me to do it !

Thanks a lot for checking this PR !