### PR TITLE
Align types for `DeferSubscription` method.

### DIFF
--- a/playstore/validator.go
+++ b/playstore/validator.go
@@ -34,7 +34,7 @@ type IABSubscription interface {
 	CancelSubscription(context.Context, string, string, string) error
 	RefundSubscription(context.Context, string, string, string) error
 	RevokeSubscription(context.Context, string, string, string) error
-	DeferSubscription(context.Context, string, string, string, *androidpublisher.SubscriptionPurchasesDeferRequest) error
+	DeferSubscription(context.Context, string, string, string, *androidpublisher.SubscriptionPurchasesDeferRequest) (*androidpublisher.SubscriptionPurchasesDeferResponse, error)
 }
 
 // The IABSubscriptionV2 type is an interface  for subscriptionV2 service

--- a/playstore/validator_test.go
+++ b/playstore/validator_test.go
@@ -257,6 +257,26 @@ func TestRevokeSubscription(t *testing.T) {
 	// TODO Normal scenario
 }
 
+func TestDeferSubscription(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client, _ := New(jsonKey)
+	deferralInfo := &androidpublisher.SubscriptionPurchasesDeferRequest{
+		DeferralInfo: &androidpublisher.SubscriptionDeferralInfo{
+			DesiredExpiryTimeMillis:  1234567890,
+			ExpectedExpiryTimeMillis: 1234567890,
+		},
+	}
+	expectedStr := "googleapi: Error 404: No application was found for the given package name., applicationNotFound"
+	_, actual := client.DeferSubscription(ctx, "package", "productID", "purchaseToken", deferralInfo)
+
+	if actual == nil || actual.Error() != expectedStr {
+		t.Errorf("got %v\nwant %v", actual, expectedStr)
+	}
+	// TODO Normal scenario
+}
+
 func TestGetSubscriptionOffer(t *testing.T) {
 	t.Parallel()
 	// Exception scenario


### PR DESCRIPTION
Getting the following error in my codebase:

```
cannot use client (variable of type *playstore.Client) as playstore.IABSubscription value in assignment: *playstore.Client does not implement playstore.IABSubscription (wrong type for method DeferSubscription)
		have DeferSubscription("context".Context, string, string, string, *androidpublisher.SubscriptionPurchasesDeferRequest) (*androidpublisher.SubscriptionPurchasesDeferResponse, error)
		want DeferSubscription("context".Context, string, string, string, *androidpublisher.SubscriptionPurchasesDeferRequest) error
```