### PR TITLE
Feat(appstore): Add refundPreference and InvalidTransactionTypeNotSupportedError to appstore server api

### DIFF
--- a/appstore/api/error.go
+++ b/appstore/api/error.go
@@ -168,4 +168,5 @@ var (
 	InvalidSampleContentProvidedError       = newError(4000041, "Invalid request. The sample content provided field is invalid")
 	InvalidUserStatusError                  = newError(4000042, "Invalid request. The user status field is invalid")
 	InvalidTransactionNotConsumableError    = newError(4000043, "Invalid request. The transaction id parameter must represent a consumable in-app purchase")
+	InvalidTransactionTypeNotSupportedError = newError(4000047, "Invalid request. The transaction id doesn't represent a supported in-app purchase type")
 )

--- a/appstore/api/model.go
+++ b/appstore/api/model.go
@@ -80,6 +80,7 @@ type ConsumptionRequestBody struct {
 	PlayTime                 int32  `json:"playTime"`
 	SampleContentProvided    bool   `json:"sampleContentProvided"`
 	UserStatus               int32  `json:"userStatus"`
+	RefundPreference         int32  `json:"refundPreference"`
 }
 
 // JWSRenewalInfoDecodedPayload https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload


### PR DESCRIPTION
Per latest 1.11 release https://developer.apple.com/documentation/appstoreserverapi/app_store_server_api_changelog

> Added the [refundPreference](https://developer.apple.com/documentation/appstoreserverapi/refundpreference) field to the [ConsumptionRequest](https://developer.apple.com/documentation/appstoreserverapi/consumptionrequest) request body.

> Added the [InvalidTransactionTypeNotSupportedError](https://developer.apple.com/documentation/appstoreserverapi/invalidtransactiontypenotsupportederror) error object.