### PR TITLE
fix(appstore): Expose the TokenIssueAt and TokenExpireAt for appstore server api to prevent 401 when default server time is abnormal

### DIFF
--- a/appstore/api/store.go
+++ b/appstore/api/store.go
@@ -38,11 +38,13 @@ const (
 )
 
 type StoreConfig struct {
-	KeyContent []byte // Loads a .p8 certificate
-	KeyID      string // Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
-	BundleID   string // Your app’s bundle ID
-	Issuer     string // Your issuer ID from the Keys page in App Store Connect (Ex: "57246542-96fe-1a63-e053-0824d011072a")
-	Sandbox    bool   // default is Production
+	KeyContent     []byte // Loads a .p8 certificate
+	KeyID          string // Your private key ID from App Store Connect (Ex: 2X9R4HXF34)
+	BundleID       string // Your app’s bundle ID
+	Issuer         string // Your issuer ID from the Keys page in App Store Connect (Ex: "57246542-96fe-1a63-e053-0824d011072a")
+	Sandbox        bool   // default is Production
+	TokenIssueAt   int64  // The token’s creation time, in UNIX time. Default is current timestamp.
+	TokenExpiredAt int64  // The token’s expiration time, in UNIX time. Default is one hour later.
 }
 
 type (

--- a/appstore/api/token.go
+++ b/appstore/api/token.go
@@ -29,11 +29,12 @@ type Token struct {
 	BundleID   string // Your app’s bundle ID
 	Issuer     string // Your issuer ID from the Keys page in App Store Connect (Ex: "57246542-96fe-1a63-e053-0824d011072a")
 	Sandbox    bool   // default is Production
+	IssueAt    int64  // The token’s creation time, in UNIX time. Default is current timestamp.
+	ExpiredAt  int64  // The token’s expiration time, in UNIX time. Tokens that expire more than 60 minutes after the time in iat are not valid (Ex: 1623086400)
 
 	// internal variables
-	AuthKey   *ecdsa.PrivateKey // .p8 private key
-	ExpiredAt int64             // The token’s expiration time, in UNIX time. Tokens that expire more than 60 minutes after the time in iat are not valid (Ex: 1623086400)
-	Bearer    string            // Authorized bearer token
+	AuthKey *ecdsa.PrivateKey // .p8 private key
+	Bearer  string            // Authorized bearer token
 }
 
 func (t *Token) WithConfig(c *StoreConfig) {
@@ -42,6 +43,8 @@ func (t *Token) WithConfig(c *StoreConfig) {
 	t.BundleID = c.BundleID
 	t.Issuer = c.Issuer
 	t.Sandbox = c.Sandbox
+	t.IssueAt = c.TokenIssueAt
+	t.ExpiredAt = c.TokenExpiredAt
 }
 
 // GenerateIfExpired checks to see if the token is about to expire and generates a new token.
@@ -73,7 +76,13 @@ func (t *Token) Generate() error {
 	t.AuthKey = key
 
 	issuedAt := time.Now().Unix()
+	if t.IssueAt > 0 {
+		issuedAt = t.IssueAt
+	}
 	expiredAt := time.Now().Add(time.Duration(1) * time.Hour).Unix()
+	if t.ExpiredAt > 0 {
+		expiredAt = t.ExpiredAt
+	}
 	jwtToken := &jwt.Token{
 		Header: map[string]interface{}{
 			"alg": "ES256",


### PR DESCRIPTION
Try to fix https://github.com/awa/go-iap/issues/277