### PR TITLE
fix(appstore): Init the bearer when Bearer is empty

### DIFF
--- a/appstore/api/token.go
+++ b/appstore/api/token.go
@@ -52,7 +52,7 @@ func (t *Token) GenerateIfExpired() (string, error) {
 	t.Lock()
 	defer t.Unlock()
 
-	if t.Expired() {
+	if t.Expired() || t.Bearer == "" {
 		err := t.Generate()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Fix the issue that when the `ExpiredAt` is set and greater than the current time, the Bearer failed to initialize for the first time.