### PR TITLE
fix(appstore): Use consistent timestamp for issued_at and expired_at

### DIFF
--- a/appstore/api/token.go
+++ b/appstore/api/token.go
@@ -76,11 +76,12 @@ func (t *Token) Generate() error {
 	}
 	t.AuthKey = key
 
-	issuedAt := time.Now().Unix()
+	now := time.Now()
+	issuedAt := now.Unix()
 	if t.IssuedAtFunc != nil {
 		issuedAt = t.IssuedAtFunc()
 	}
-	expiredAt := time.Now().Add(time.Duration(1) * time.Hour).Unix()
+	expiredAt := now.Add(time.Duration(1) * time.Hour).Unix()
 	if t.ExpiredAtFunc != nil {
 		expiredAt = t.ExpiredAtFunc()
 	}


### PR DESCRIPTION
docs: https://developer.apple.com/documentation/appstoreserverapi/generating_json_web_tokens_for_api_requests

In the existing code, time.Now() is called twice separately for issued_at and expired_at. This introduces the possibility of a time gap between these two calls. As a result, the difference between expired_at and issued_at might exceed 60 minutes.

By calling time.Now() only once and storing its value in a variable, we ensure that both issued_at and expired_at refer to the exact same point in time, thus maintaining the expected 60-minute difference between them.

