### PR TITLE
feat(appstore): add get transaction history v2 and the fields renewalPrice, currency, and offerDiscountType to the JWSRenewalInfoDecodedPayload

### DIFF
--- a/appstore/api/model.go
+++ b/appstore/api/model.go
@@ -85,20 +85,23 @@ type ConsumptionRequestBody struct {
 
 // JWSRenewalInfoDecodedPayload https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload
 type JWSRenewalInfoDecodedPayload struct {
-	AutoRenewProductId          string          `json:"autoRenewProductId"`
-	AutoRenewStatus             AutoRenewStatus `json:"autoRenewStatus"`
-	Environment                 Environment     `json:"environment"`
-	ExpirationIntent            int32           `json:"expirationIntent"`
-	GracePeriodExpiresDate      int64           `json:"gracePeriodExpiresDate"`
-	IsInBillingRetryPeriod      *bool           `json:"isInBillingRetryPeriod"`
-	OfferIdentifier             string          `json:"offerIdentifier"`
-	OfferType                   int32           `json:"offerType"`
-	OriginalTransactionId       string          `json:"originalTransactionId"`
-	PriceIncreaseStatus         *int32          `json:"priceIncreaseStatus"`
-	ProductId                   string          `json:"productId"`
-	RecentSubscriptionStartDate int64           `json:"recentSubscriptionStartDate"`
-	RenewalDate                 int64           `json:"renewalDate"`
-	SignedDate                  int64           `json:"signedDate"`
+	AutoRenewProductId          string            `json:"autoRenewProductId"`
+	AutoRenewStatus             AutoRenewStatus   `json:"autoRenewStatus"`
+	Environment                 Environment       `json:"environment"`
+	ExpirationIntent            int32             `json:"expirationIntent"`
+	GracePeriodExpiresDate      int64             `json:"gracePeriodExpiresDate"`
+	IsInBillingRetryPeriod      *bool             `json:"isInBillingRetryPeriod"`
+	OfferIdentifier             string            `json:"offerIdentifier"`
+	OfferType                   int32             `json:"offerType"`
+	OriginalTransactionId       string            `json:"originalTransactionId"`
+	PriceIncreaseStatus         *int32            `json:"priceIncreaseStatus"`
+	ProductId                   string            `json:"productId"`
+	RecentSubscriptionStartDate int64             `json:"recentSubscriptionStartDate"`
+	RenewalDate                 int64             `json:"renewalDate"`
+	SignedDate                  int64             `json:"signedDate"`
+	RenewalPrice                int64             `json:"renewalPrice,omitempty"`
+	Currency                    string            `json:"currency,omitempty"`
+	OfferDiscountType           OfferDiscountType `json:"offerDiscountType,omitempty"`
 }
 
 func (J JWSRenewalInfoDecodedPayload) Valid() error {

--- a/appstore/api/store.go
+++ b/appstore/api/store.go
@@ -24,7 +24,8 @@ const (
 	HostProduction = "https://api.storekit.itunes.apple.com"
 
 	PathLookUp                              = "/inApps/v1/lookup/{orderId}"
-	PathTransactionHistory                  = "/inApps/v1/history/{originalTransactionId}"
+	PathTransactionHistory                  = "/inApps/v2/history/{originalTransactionId}"
+	PathTransactionHistoryV1                = "/inApps/v1/history/{originalTransactionId}"
 	PathTransactionInfo                     = "/inApps/v1/transactions/{transactionId}"
 	PathRefundHistory                       = "/inApps/v2/refund/lookup/{originalTransactionId}"
 	PathGetALLSubscriptionStatus            = "/inApps/v1/subscriptions/{originalTransactionId}"


### PR DESCRIPTION
Support [1.12](https://developer.apple.com/documentation/appstoreserverapi/app_store_server_api_changelog#4408522)

New features

- Added the endpoint [Get Transaction History](https://developer.apple.com/documentation/appstoreserverapi/get_transaction_history), which provides transaction history for all in-app purchases, including consumable in-app purchases in a finished state.

- Added the fields [renewalPrice](https://developer.apple.com/documentation/appstoreserverapi/renewalprice), [currency](https://developer.apple.com/documentation/appstoreserverapi/currency), and [offerDiscountType](https://developer.apple.com/documentation/appstoreserverapi/offerdiscounttype) to the [JWSRenewalInfoDecodedPayload](https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload).

Deprecations

- The [Get Transaction History V1](https://developer.apple.com/documentation/appstoreserverapi/get_transaction_history_v1) endpoint is deprecated. Use the new [Get Transaction History](https://developer.apple.com/documentation/appstoreserverapi/get_transaction_history) endpoint instead.