### PR TITLE
feat(appstore): add eligibleWinBackOfferIds field to JWSRenewalInfoDecodedPayload 

### DIFF
--- a/appstore/api/model.go
+++ b/appstore/api/model.go
@@ -102,6 +102,7 @@ type JWSRenewalInfoDecodedPayload struct {
 	RenewalPrice                int64             `json:"renewalPrice,omitempty"`
 	Currency                    string            `json:"currency,omitempty"`
 	OfferDiscountType           OfferDiscountType `json:"offerDiscountType,omitempty"`
+	EligibleWinBackOfferIds     []string          `json:"eligibleWinBackOfferIds,omitempty"`
 }
 
 func (J JWSRenewalInfoDecodedPayload) Valid() error {


### PR DESCRIPTION
Per app store api version 1.13 https://developer.apple.com/documentation/appstoreserverapi/app_store_server_api_changelog#4444148

> Updated the [JWSRenewalInfoDecodedPayload](https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload) to include the new [eligibleWinBackOfferIds](https://developer.apple.com/documentation/appstoreserverapi/eligiblewinbackofferids) field.