### PR TITLE
fix(playstore): correct the number of parameters of VerifySubscriptionV2

### DIFF
--- a/playstore/mocks/playstore.go
+++ b/playstore/mocks/playstore.go
@@ -230,18 +230,18 @@ func (mr *MockIABSubscriptionV2MockRecorder) RevokeSubscriptionV2(arg0, arg1, ar
 }
 
 // VerifySubscriptionV2 mocks base method.
-func (m *MockIABSubscriptionV2) VerifySubscriptionV2(arg0 context.Context, arg1, arg2, arg3 string) (*androidpublisher.SubscriptionPurchaseV2, error) {
+func (m *MockIABSubscriptionV2) VerifySubscriptionV2(arg0 context.Context, arg1, arg2 string) (*androidpublisher.SubscriptionPurchaseV2, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifySubscriptionV2", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "VerifySubscriptionV2", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*androidpublisher.SubscriptionPurchaseV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // VerifySubscriptionV2 indicates an expected call of VerifySubscriptionV2.
-func (mr *MockIABSubscriptionV2MockRecorder) VerifySubscriptionV2(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockIABSubscriptionV2MockRecorder) VerifySubscriptionV2(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifySubscriptionV2", reflect.TypeOf((*MockIABSubscriptionV2)(nil).VerifySubscriptionV2), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifySubscriptionV2", reflect.TypeOf((*MockIABSubscriptionV2)(nil).VerifySubscriptionV2), arg0, arg1, arg2)
 }
 
 // MockIABMonetization is a mock of IABMonetization interface.

--- a/playstore/validator.go
+++ b/playstore/validator.go
@@ -39,7 +39,7 @@ type IABSubscription interface {
 
 // The IABSubscriptionV2 type is an interface  for subscriptionV2 service
 type IABSubscriptionV2 interface {
-	VerifySubscriptionV2(context.Context, string, string, string) (*androidpublisher.SubscriptionPurchaseV2, error)
+	VerifySubscriptionV2(context.Context, string, string) (*androidpublisher.SubscriptionPurchaseV2, error)
 	RevokeSubscriptionV2(context.Context, string, string, *androidpublisher.RevokeSubscriptionPurchaseRequest) (*androidpublisher.RevokeSubscriptionPurchaseResponse, error)
 }
 


### PR DESCRIPTION
Related issue https://github.com/awa/go-iap/issues/292