### PR TITLE
feat(appstore): add more fields

### DIFF
--- a/appstore/api/error.go
+++ b/appstore/api/error.go
@@ -169,4 +169,5 @@ var (
 	InvalidUserStatusError                  = newError(4000042, "Invalid request. The user status field is invalid")
 	InvalidTransactionNotConsumableError    = newError(4000043, "Invalid request. The transaction id parameter must represent a consumable in-app purchase")
 	InvalidTransactionTypeNotSupportedError = newError(4000047, "Invalid request. The transaction id doesn't represent a supported in-app purchase type")
+	AppTransactionIdNotSupportedError       = newError(4000048, "Invalid request. Invalid request. App transactions aren't supported by this endpoint")
 )

--- a/appstore/api/model.go
+++ b/appstore/api/model.go
@@ -91,6 +91,8 @@ var _ jwt.Claims = JWSRenewalInfoDecodedPayload{}
 
 // JWSRenewalInfoDecodedPayload https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload
 type JWSRenewalInfoDecodedPayload struct {
+	AppAccountToken             string            `json:"appAccountToken,omitempty"`
+	AppTransactionId            string            `json:"appTransactionId,omitempty"`
 	AutoRenewProductId          string            `json:"autoRenewProductId"`
 	AutoRenewStatus             AutoRenewStatus   `json:"autoRenewStatus"`
 	Environment                 Environment       `json:"environment"`
@@ -99,6 +101,7 @@ type JWSRenewalInfoDecodedPayload struct {
 	IsInBillingRetryPeriod      *bool             `json:"isInBillingRetryPeriod"`
 	OfferIdentifier             string            `json:"offerIdentifier"`
 	OfferType                   int32             `json:"offerType"`
+	OfferPeriod                 string            `json:"offerPeriod"`
 	OriginalTransactionId       string            `json:"originalTransactionId"`
 	PriceIncreaseStatus         *int32            `json:"priceIncreaseStatus"`
 	ProductId                   string            `json:"productId"`
@@ -180,6 +183,7 @@ var _ jwt.Claims = JWSTransaction{}
 
 // JWSTransaction https://developer.apple.com/documentation/appstoreserverapi/jwstransaction
 type JWSTransaction struct {
+	AppTransactionId            string            `json:"appTransactionId,omitempty"`
 	TransactionID               string            `json:"transactionId,omitempty"`
 	OriginalTransactionId       string            `json:"originalTransactionId,omitempty"`
 	WebOrderLineItemId          string            `json:"webOrderLineItemId,omitempty"`
@@ -195,6 +199,7 @@ type JWSTransaction struct {
 	InAppOwnershipType          string            `json:"inAppOwnershipType,omitempty"`
 	SignedDate                  int64             `json:"signedDate,omitempty"`
 	OfferType                   int32             `json:"offerType,omitempty"`
+	OfferPeriod                 string            `json:"offerPeriod,omitempty"`
 	OfferIdentifier             string            `json:"offerIdentifier,omitempty"`
 	RevocationDate              int64             `json:"revocationDate,omitempty"`
 	RevocationReason            *int32            `json:"revocationReason,omitempty"`


### PR DESCRIPTION
Per release note https://developer.apple.com/documentation/appstoreserverapi/app-store-server-api-changelog, add more fileds

-----

[1.15 - 2025/02/21](https://developer.apple.com/documentation/appstoreserverapi/app-store-server-api-changelog#115-20250221)
New features

Updated the [JWSRenewalInfoDecodedPayload](https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload) and [JWSTransactionDecodedPayload](https://developer.apple.com/documentation/appstoreserverapi/jwstransactiondecodedpayload) to include the new [appTransactionId](https://developer.apple.com/documentation/appstoreserverapi/apptransactionid) and [offerPeriod](https://developer.apple.com/documentation/appstoreserverapi/offerperiod) fields.

Updated the [JWSRenewalInfoDecodedPayload](https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload) to include the [appAccountToken](https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken) field.

Added the [AppTransactionIdNotSupportedError](https://developer.apple.com/documentation/appstoreserverapi/apptransactionidnotsupportederror) error object.