### PR TITLE
feat(appstore): Support 1.19: add the Send Consumption Information endpoint 

### DIFF
--- a/appstore/api/model.go
+++ b/appstore/api/model.go
@@ -70,7 +70,34 @@ type MassExtendRenewalDateRequest struct {
 	StorefrontCountryCodes []string `json:"storefrontCountryCodes"`
 }
 
+type DeliveryStatus string
+
+// DeliveryStatus https://developer.apple.com/documentation/appstoreserverapi/deliverystatus
+const (
+	DELIVERED                 DeliveryStatus = "DELIVERED"
+	UNDELIVERED_QUALITY_ISSUE DeliveryStatus = "UNDELIVERED_QUALITY_ISSUE"
+	UNDELIVERED_WRONG_ITEM    DeliveryStatus = "UNDELIVERED_WRONG_ITEM"
+	UNDELIVERED_SERVER_OUTAGE DeliveryStatus = "UNDELIVERED_SERVER_OUTAGE"
+	UNDELIVERED_OTHER         DeliveryStatus = "UNDELIVERED_OTHER"
+)
+
+type RefundPreference string
+
+// RefundPreference https://developer.apple.com/documentation/appstoreserverapi/refundpreference
+const (
+	DECLINE        RefundPreference = "DECLINE"
+	GRANT_FULL     RefundPreference = "GRANT_FULL"
+	GRANT_PRORATED RefundPreference = "GRANT_PRORATED"
+)
+
 // ConsumptionRequestBody https://developer.apple.com/documentation/appstoreserverapi/consumptionrequest
+type ConsumptionRequest struct {
+	CustomerConsented     bool             `json:"customerConsented"`
+	ConsumptionPercentage int32            `json:"consumptionPercentage"`
+	DeliveryStatus        DeliveryStatus   `json:"deliveryStatus"`
+	RefundPreference      RefundPreference `json:"refundPreference"`
+	SampleContentProvided bool             `json:"sampleContentProvided"`
+}
 type ConsumptionRequestBody struct {
 	AccountTenure            int32  `json:"accountTenure"`
 	AppAccountToken          string `json:"appAccountToken"`
@@ -86,32 +113,70 @@ type ConsumptionRequestBody struct {
 	RefundPreference         int32  `json:"refundPreference"`
 }
 
+type AdvancedCommerceDescriptors struct {
+	Description string `json:"description"`
+	DisplayName string `json:"displayName"`
+}
+
+type AdvancedCommercePriceIncreaseInfo struct {
+	DependentSKUs []string `json:"dependentSKUs"`
+	Price         int64    `json:"price"`
+	Status        string   `json:"status"`
+}
+
+type AdvancedCommerceOffer struct {
+	Period      string `json:"period"`
+	PeriodCount int32  `json:"periodCount"`
+	Price       int64  `json:"price"`
+	Reason      string `json:"reason"`
+}
+
+type AdvancedCommerceRenewalItems struct {
+	SKU               string                            `json:"SKU"`
+	Description       string                            `json:"description"`
+	DisplayName       string                            `json:"displayName"`
+	Offer             AdvancedCommerceOffer             `json:"offer"`
+	Price             int64                             `json:"price"`
+	PriceIncreaseInfo AdvancedCommercePriceIncreaseInfo `json:"priceIncreaseInfo"`
+}
+
+// AdvancedCommerceRenewalInfo https://developer.apple.com/documentation/appstoreserverapi/advancedcommercerenewalinfo
+type AdvancedCommerceRenewalInfo struct {
+	ConsistencyToken   string                         `json:"consistencyToken"`
+	Descriptors        AdvancedCommerceDescriptors    `json:"descriptors"`
+	Items              []AdvancedCommerceRenewalItems `json:"items"`
+	Period             string                         `json:"period"`
+	RequestReferenceId string                         `json:"requestReferenceId"`
+	TaxCode            string                         `json:"taxCode"`
+}
+
 // Verify that JWSRenewalInfoDecodedPayload implements jwt.Claims
 var _ jwt.Claims = JWSRenewalInfoDecodedPayload{}
 
 // JWSRenewalInfoDecodedPayload https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload
 type JWSRenewalInfoDecodedPayload struct {
-	AppAccountToken             string            `json:"appAccountToken,omitempty"`
-	AppTransactionId            string            `json:"appTransactionId,omitempty"`
-	AutoRenewProductId          string            `json:"autoRenewProductId"`
-	AutoRenewStatus             AutoRenewStatus   `json:"autoRenewStatus"`
-	Environment                 Environment       `json:"environment"`
-	ExpirationIntent            int32             `json:"expirationIntent"`
-	GracePeriodExpiresDate      int64             `json:"gracePeriodExpiresDate"`
-	IsInBillingRetryPeriod      *bool             `json:"isInBillingRetryPeriod"`
-	OfferIdentifier             string            `json:"offerIdentifier"`
-	OfferType                   int32             `json:"offerType"`
-	OfferPeriod                 string            `json:"offerPeriod"`
-	OriginalTransactionId       string            `json:"originalTransactionId"`
-	PriceIncreaseStatus         *int32            `json:"priceIncreaseStatus"`
-	ProductId                   string            `json:"productId"`
-	RecentSubscriptionStartDate int64             `json:"recentSubscriptionStartDate"`
-	RenewalDate                 int64             `json:"renewalDate"`
-	SignedDate                  int64             `json:"signedDate"`
-	RenewalPrice                int64             `json:"renewalPrice,omitempty"`
-	Currency                    string            `json:"currency,omitempty"`
-	OfferDiscountType           OfferDiscountType `json:"offerDiscountType,omitempty"`
-	EligibleWinBackOfferIds     []string          `json:"eligibleWinBackOfferIds,omitempty"`
+	AppAccountToken             string                      `json:"appAccountToken,omitempty"`
+	AppTransactionId            string                      `json:"appTransactionId,omitempty"`
+	AutoRenewProductId          string                      `json:"autoRenewProductId"`
+	AutoRenewStatus             AutoRenewStatus             `json:"autoRenewStatus"`
+	Environment                 Environment                 `json:"environment"`
+	ExpirationIntent            int32                       `json:"expirationIntent"`
+	GracePeriodExpiresDate      int64                       `json:"gracePeriodExpiresDate"`
+	IsInBillingRetryPeriod      *bool                       `json:"isInBillingRetryPeriod"`
+	OfferIdentifier             string                      `json:"offerIdentifier"`
+	OfferType                   int32                       `json:"offerType"`
+	OfferPeriod                 string                      `json:"offerPeriod"`
+	OriginalTransactionId       string                      `json:"originalTransactionId"`
+	PriceIncreaseStatus         *int32                      `json:"priceIncreaseStatus"`
+	ProductId                   string                      `json:"productId"`
+	RecentSubscriptionStartDate int64                       `json:"recentSubscriptionStartDate"`
+	RenewalDate                 int64                       `json:"renewalDate"`
+	SignedDate                  int64                       `json:"signedDate"`
+	RenewalPrice                int64                       `json:"renewalPrice,omitempty"`
+	Currency                    string                      `json:"currency,omitempty"`
+	OfferDiscountType           OfferDiscountType           `json:"offerDiscountType,omitempty"`
+	EligibleWinBackOfferIds     []string                    `json:"eligibleWinBackOfferIds,omitempty"`
+	AdvancedCommerceInfo        AdvancedCommerceRenewalInfo `json:"advancedCommerceInfo,omitempty"`
 }
 
 // GetAudience implements jwt.Claims.
@@ -179,6 +244,14 @@ const (
 	OfferDiscountTypeOneTime    OfferDiscountType = "ONE_TIME"
 )
 
+type RevocationType string
+
+const (
+	REFUND_FULL     RevocationType = "REFUND_FULL"
+	REFUND_PRORATED RevocationType = "REFUND_PRORATED"
+	FAMILY_REVOKE   RevocationType = "FAMILY_REVOKE"
+)
+
 // Verify that JWSTransaction implements jwt.Claims
 var _ jwt.Claims = JWSTransaction{}
 
@@ -204,6 +277,8 @@ type JWSTransaction struct {
 	OfferIdentifier             string            `json:"offerIdentifier,omitempty"`
 	RevocationDate              int64             `json:"revocationDate,omitempty"`
 	RevocationReason            *int32            `json:"revocationReason,omitempty"`
+	RevocationType              RevocationType    `json:"revocationType,omitempty"`
+	RevocationPercentage        int32             `json:"revocationPercentage,omitempty"`
 	IsUpgraded                  bool              `json:"isUpgraded,omitempty"`
 	Storefront                  string            `json:"storefront,omitempty"`
 	StorefrontId                string            `json:"storefrontId,omitempty"`

--- a/appstore/api/store.go
+++ b/appstore/api/store.go
@@ -29,6 +29,7 @@ const (
 	PathTransactionInfo                     = "/inApps/v1/transactions/{transactionId}"
 	PathRefundHistory                       = "/inApps/v2/refund/lookup/{originalTransactionId}"
 	PathGetALLSubscriptionStatus            = "/inApps/v1/subscriptions/{originalTransactionId}"
+	PathConsumptionInfoV2                   = "/inApps/v2/transactions/consumption/{transactionId}"
 	PathConsumptionInfo                     = "/inApps/v1/transactions/consumption/{originalTransactionId}"
 	PathExtendSubscriptionRenewalDate       = "/inApps/v1/subscriptions/extend/{originalTransactionId}"
 	PathExtendSubscriptionRenewalDateForAll = "/inApps/v1/subscriptions/extend/mass/"
@@ -98,6 +99,7 @@ type (
 
 	ConsumptionSender interface {
 		SendConsumptionInfo(ctx context.Context, originalTransactionId string, body ConsumptionRequestBody) (statusCode int, err error)
+		SendConsumptionInfoV2(ctx context.Context, transactionId string, body ConsumptionRequest) (statusCode int, err error)
 	}
 
 	AppAccountSetter interface {
@@ -321,10 +323,28 @@ func (a *StoreClient) GetRefundHistory(ctx context.Context, originalTransactionI
 	return
 }
 
-// SendConsumptionInfo https://developer.apple.com/documentation/appstoreserverapi/send_consumption_information
+// https://developer.apple.com/documentation/appstoreserverapi/send-consumption-information-v1
 func (a *StoreClient) SendConsumptionInfo(ctx context.Context, originalTransactionId string, body ConsumptionRequestBody) (statusCode int, err error) {
 	URL := a.host + PathConsumptionInfo
 	URL = strings.Replace(URL, "{originalTransactionId}", originalTransactionId, -1)
+
+	bodyBuf := new(bytes.Buffer)
+	err = json.NewEncoder(bodyBuf).Encode(body)
+	if err != nil {
+		return 0, err
+	}
+
+	statusCode, _, err = a.Do(ctx, http.MethodPut, URL, bodyBuf)
+	if err != nil {
+		return statusCode, err
+	}
+	return statusCode, nil
+}
+
+// SendConsumptionInfoV2 https://developer.apple.com/documentation/appstoreserverapi/send-consumption-information
+func (a *StoreClient) SendConsumptionInfoV2(ctx context.Context, transactionId string, body ConsumptionRequest) (statusCode int, err error) {
+	URL := a.host + PathConsumptionInfoV2
+	URL = strings.Replace(URL, "{transactionId}", transactionId, -1)
 
 	bodyBuf := new(bytes.Buffer)
 	err = json.NewEncoder(bodyBuf).Encode(body)


### PR DESCRIPTION
Add the Send Consumption Information endpoint  and more fields to JWSTransactionDecodedPayload and JWSRenewalInfoDecodedPayload