### PR TITLE
feat(appstore): update server domain

### DIFF
--- a/appstore/api/store.go
+++ b/appstore/api/store.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	HostSandBox    = "https://api.storekit-sandbox.itunes.apple.com"
-	HostProduction = "https://api.storekit.itunes.apple.com"
+	HostSandBox    = "https://api.storekit-sandbox.apple.com"
+	HostProduction = "https://api.storekit.apple.com"
 
 	PathLookUp                              = "/inApps/v1/lookup/{orderId}"
 	PathTransactionHistory                  = "/inApps/v2/history/{transactionId}"


### PR DESCRIPTION
Per doc https://developer.apple.com/documentation/appstoreserverapi/app-store-server-api-changelog

> Updated recommended domain from api.storekit.itunes.apple.com to api.storekit.apple.com, and api.storekit-sandbox.itunes.apple.com to api.storekit-sandbox.apple.com. The previous domains will continue to be supported.